### PR TITLE
fix health check artisan command for manually running checks docs

### DIFF
--- a/docs/basic-usage/manually-running-checks.md
+++ b/docs/basic-usage/manually-running-checks.md
@@ -8,7 +8,7 @@ All registered checks will run automatically when the `RunHealthChecksCommand` e
 You can also decide to manually run the command with:
 
 ```bash
-php artisan health:checks
+php artisan health:check
 ```
 
 ## Fail the command when a check fails
@@ -16,7 +16,7 @@ php artisan health:checks
 By default, the `RunHealthChecksCommand` will always return a successful exit code (`1`). When you pass the `--fail-command-on-failing-check`, then the exit code of the command will be non-successful (`0`) when one of the checks fails.
 
 ```bash
-php artisan health:checks --fail-command-on-failing-check
+php artisan health:check --fail-command-on-failing-check
 ```
 
 ## Avoid sending notifications
@@ -24,7 +24,7 @@ php artisan health:checks --fail-command-on-failing-check
 The `RunHealthChecksCommand` will send a notification when one of the checks fails. If you want to avoid sending a notification, you can pass the `--no-notification` option.
 
 ```bash
-php artisan health:checks --no-notification
+php artisan health:check --no-notification
 ```
 
 ## Avoid storing results
@@ -32,7 +32,5 @@ php artisan health:checks --no-notification
 If you've configured [a result store](https://spatie.be/docs/laravel-health/v1/storing-results/general), then `RunHealthChecksCommand` will store the results. If you want to avoid storing results for a manual run, your can use the `--do-not-store-results` option.
 
 ```bash
-php artisan health:checks --do-not-store-results
+php artisan health:check --do-not-store-results
 ```
-
-


### PR DESCRIPTION
After installing the package in a fresh laravel project I referred to this page of the documentation:
https://spatie.be/docs/laravel-health/v1/basic-usage/manually-running-checks
Run the following command:
```
php artisan health:checks
```
Output:
```
 Command "health:checks" is not defined.  
                                           
  Did you mean one of these?               
      health:check                         
      health:list                          
      health:schedule-check-heartbeat    
```
So, fixed the corresponding file for the documentation. Please review.