### PR TITLE
Fix regular expression for used disk space check output

### DIFF
--- a/src/Checks/Checks/UsedDiskSpaceCheck.php
+++ b/src/Checks/Checks/UsedDiskSpaceCheck.php
@@ -53,6 +53,6 @@ class UsedDiskSpaceCheck extends Check
 
         $output = $process->getOutput();
 
-        return (int) Regex::match('/(\d*\d)%/', $output)->group(1);
+        return (int) Regex::match('/(\d*)%/', $output)->group(1);
     }
 }

--- a/src/Checks/Checks/UsedDiskSpaceCheck.php
+++ b/src/Checks/Checks/UsedDiskSpaceCheck.php
@@ -53,6 +53,6 @@ class UsedDiskSpaceCheck extends Check
 
         $output = $process->getOutput();
 
-        return (int) Regex::match('/(\d?\d)%/', $output)->group(1);
+        return (int) Regex::match('/(\d*\d)%/', $output)->group(1);
     }
 }


### PR DESCRIPTION
The current regular expression, which matches the command line output for the used disk space check, parses a maximum of two digits.
[Example](https://regexr.com/6be7s)

This means that a disk usage of 100% is actually parsed as 00%, which is obviously wrong. I think it is okay to simply parse any digit before the % sign.
[Example](https://regexr.com/6be8b)