### PR TITLE
Fix incorrect class name

### DIFF
--- a/docs/storing-results/general.md
+++ b/docs/storing-results/general.md
@@ -8,7 +8,7 @@ When `RunHealthChecksCommand` executes, all checks will be run. The results of t
 - `EloquentHealthResultStore`: will store all results in the database
 - `CacheHealthResultStore`: will store all results in cache
 - `JsonFileHealthResultStore`: will store all results in a JSON file.
-- `InMemoraryResultStore`: will not store results at all
+- `InMemoryHealthResultStore`: will not store results at all
 
 You can configure the stores to be used, by adding the store class name to the `result_stores` key of the `health` config file. 
 


### PR DESCRIPTION
The class name provided in the documentation seems to be incorrect. I've updated it to match the class file.