### PR TITLE
Support custom tables names when using EloquentHealthResultStore (and fix typos in docs)

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -17,7 +17,7 @@ return [
             'store' => 'file',
         ],
 
-        Spatie\Health\ResultStores\EloquentHealthResultStore\JsonFileHealthResultStore::class => [
+        Spatie\Health\ResultStores\JsonFileHealthResultStore::class => [
             'disk' => 's3',
             'path' => 'health.json',
         ],

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -3,12 +3,13 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Spatie\Health\Models\HealthCheckResultHistoryItem;
 
 return new class extends Migration
 {
     public function up()
     {
-        Schema::create('health_check_result_history_items', function (Blueprint $table) {
+        Schema::create(HealthCheckResultHistoryItem::getTable(), function (Blueprint $table) {
             $table->id();
 
             $table->string('check_name');

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -9,7 +9,12 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create(HealthCheckResultHistoryItem::getTable(), function (Blueprint $table) {
+        $tableName = config(
+            'health.result_stores.' . EloquentHealthResultStore::class . '.table',
+            'health_check_result_history_items'
+        );
+    
+        Schema::create($tableName, function (Blueprint $table) {
             $table->id();
 
             $table->string('check_name');

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -37,7 +37,7 @@ return [
             'store' => 'file',
         ],
 
-        Spatie\Health\ResultStores\EloquentHealthResultStore\JsonFileHealthResultStore::class => [
+        Spatie\Health\ResultStores\JsonFileHealthResultStore::class => [
             'disk' => 's3',
             'path' => 'health.json',
         ],
@@ -135,7 +135,7 @@ return [
 
 ## Migrating the database
 
-This package can store health check results [in various ways](https://spatie.be/docs/laravel-health/v1/storing-results/general). When using the `EloquentHealthResultStore` the check results will be stored in the database. To create the `check_result_history_items` table, you must create and run the migration.
+This package can store health check results [in various ways](https://spatie.be/docs/laravel-health/v1/storing-results/general). When using the `EloquentHealthResultStore` the check results will be stored in the database. To create the `health_check_result_history_items` table, you must create and run the migration.
 
 ```bash
 php artisan vendor:publish --tag="health-migrations"
@@ -143,6 +143,20 @@ php artisan migrate
 ```
 
 These steps are not necessary when using the `JsonFileResultStore`.
+
+## Using a custom table name with `EloquentHealthResultStore`
+
+By default, `EloquentHealthResultStore` will save results to a table called `health_check_result_history_items`. To change the table name, update the `health.php` config file and add a `table` key to the `EloquentHealthResultStore` array:
+
+```php
+//...
+'result_stores'    => [
+    Spatie\Health\ResultStores\EloquentHealthResultStore::class => [
+        'keep_history_for_days' => 7,
+        'table'                 => 'my_health_checks',
+    ],
+    // ...
+```
 
 ## Running the checks by scheduling a command
 

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -31,6 +31,11 @@ class HealthCheckResultHistoryItem extends Model
         'meta' => 'array',
         'started_failing_at' => 'timestamp',
     ];
+    
+    public function getTable()
+    {
+        return config('health.result_stores.'  . EloquentHealthResultStore::class.  '.table') ?? parent::getTable();
+    }
 
     public function prunable(): Builder
     {


### PR DESCRIPTION
The package currently forces you to use a table called `health_check_result_history_items`. If you're a pedant (like me), and use specific table-naming conventions, it wasn't previously possible to override this (at least not without extending multiple classes).

I've added a check to see if the `health.php` config file contains a custom `table` key — if so, the `HealthCheckResultHistoryItem` model will use this table name. If not, it falls back to the default naming convention.

This change is backwards-compatible. I've also fixed a couple of typos I noticed in the docs.

Thanks for a great package! Looking forward to setting it up with Oh Dear 👍