### PR TITLE
Add support for custom HealthCheckResultHistoryItem models

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -9,6 +9,7 @@ return [
      */
     'result_stores' => [
         Spatie\Health\ResultStores\EloquentHealthResultStore::class => [
+            'model' => Spatie\Health\Models\HealthCheckResultHistoryItem::class,
             'keep_history_for_days' => 5,
         ],
 

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -3,12 +3,13 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Spatie\Health\ResultStores\EloquentHealthResultStore;
 
 return new class extends Migration
 {
     public function up()
     {
-        Schema::create('health_check_result_history_items', function (Blueprint $table) {
+        Schema::create(EloquentHealthResultStore::getHistoryItemInstance()->getTable(), function (Blueprint $table) {
             $table->id();
 
             $table->string('check_name');

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -9,7 +9,9 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create(EloquentHealthResultStore::getHistoryItemInstance()->getTable(), function (Blueprint $table) {
+        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
+    
+        Schema::create($tableName, function (Blueprint $table) {
             $table->id();
 
             $table->string('check_name');

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -29,6 +29,7 @@ return [
      */
     'result_stores' => [
         Spatie\Health\ResultStores\EloquentHealthResultStore::class => [
+            'model' => Spatie\Health\Models\HealthCheckResultHistoryItem::class,
             'keep_history_for_days' => 5,
         ],
 

--- a/docs/storing-results/in-the-database.md
+++ b/docs/storing-results/in-the-database.md
@@ -16,6 +16,19 @@ return [
 
 The results will be written in the `health_check_result_history_items` table. All field names should be self-explanatory. Using the `App\Spatie\Models\HealthCheckResultHistoryItem` model, you can easily query all results.
 
+## Using a custom model
+
+If you'd like to use a custom model for storing health check results, extend the `Spatie\Health\Models\HealthCheckResultHistoryItem` class, and add it to the `EloquentHealthResultStore` configuration:
+
+```php
+return [
+    'result_stores' => [
+        Spatie\Health\ResultStores\EloquentHealthResultStore::class => [
+            'model' => App\Models\CustomHealthCheckResultModel::class,
+        ],
+    ],
+```
+
 ## Pruning the results table
 
 The model uses the [Laravel's `MassPrunable` trait](https://laravel.com/docs/8.x/eloquent#mass-pruning). In the `health` config file, you can specify the maximum age of a model in the `keep_history_for_days` key. Don't forget to schedule the `model:prune` command, as instructed in Laravel's docs.

--- a/src/Exceptions/CouldNotSaveResultsInStore.php
+++ b/src/Exceptions/CouldNotSaveResultsInStore.php
@@ -4,6 +4,7 @@ namespace Spatie\Health\Exceptions;
 
 use Exception;
 use Spatie\Health\ResultStores\ResultStore;
+use Spatie\Health\Models\HealthCheckResultHistoryItem;
 
 class CouldNotSaveResultsInStore extends Exception
 {
@@ -14,6 +15,13 @@ class CouldNotSaveResultsInStore extends Exception
         return new self(
             message: "Could not save results in the `{$storeClass}` did not complete. An exception was thrown with this message: `{$exception->getMessage()}`",
             previous: $exception,
+        );
+    }
+    
+    public static function doesNotExtendHealthCheckResultHistoryItem(mixed $invalidValue): self
+    {
+        return new self(
+            "You tried to register an invalid HealthCheckResultHistoryItem model: `{$invalidValue}`. A valid model should extend " . HealthCheckResultHistoryItem::class
         );
     }
 }

--- a/src/Exceptions/CouldNotSaveResultsInStore.php
+++ b/src/Exceptions/CouldNotSaveResultsInStore.php
@@ -20,8 +20,10 @@ class CouldNotSaveResultsInStore extends Exception
     
     public static function doesNotExtendHealthCheckResultHistoryItem(mixed $invalidValue): self
     {
+        $className = HealthCheckResultHistoryItem::class;
+
         return new self(
-            "You tried to register an invalid HealthCheckResultHistoryItem model: `{$invalidValue}`. A valid model should extend " . HealthCheckResultHistoryItem::class
+            "You tried to register an invalid HealthCheckResultHistoryItem model: `{$invalidValue}`. A valid model should extend `{$className}`"
         );
     }
 }

--- a/src/ResultStores/EloquentHealthResultStore.php
+++ b/src/ResultStores/EloquentHealthResultStore.php
@@ -27,7 +27,7 @@ class EloquentHealthResultStore implements ResultStore
         return $historyItemModel;
     }
 
-    /** @return HealthCheckResultHistoryItem */
+    /** @return HealthCheckResultHistoryItem|object */
     public static function getHistoryItemInstance()
     {
         $historyItemClassName = static::determineHistoryItemModel();

--- a/src/ResultStores/EloquentHealthResultStore.php
+++ b/src/ResultStores/EloquentHealthResultStore.php
@@ -16,7 +16,7 @@ class EloquentHealthResultStore implements ResultStore
     public static function determineHistoryItemModel(): string
     {
         $historyItemModel = config(
-        'health.result_stores.' . EloquentHealthResultStore::class . '.model',
+            'health.result_stores.' . EloquentHealthResultStore::class . '.model',
             HealthCheckResultHistoryItem::class,
         );
 

--- a/src/ResultStores/EloquentHealthResultStore.php
+++ b/src/ResultStores/EloquentHealthResultStore.php
@@ -28,7 +28,7 @@ class EloquentHealthResultStore implements ResultStore
     }
 
     /** @return HealthCheckResultHistoryItem */
-    public static function getHistoryItemInstance(): HealthCheckResultHistoryItem
+    public static function getHistoryItemInstance()
     {
         $historyItemClassName = static::determineHistoryItemModel();
 


### PR DESCRIPTION
As discussed in https://github.com/spatie/laravel-health/pull/16 — this PR implements a `model` config parameter, for use by the `EloquentHealthResultStore` class.

I followed the general conventions used by http://github.com/spatie/laravel-activitylog for setting custom models — hopefully that's along the right lines this time.

This PR is backwards-compatible.

Thanks! 🙌