### PR TITLE
Remove `@ray` from view

### DIFF
--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -22,7 +22,6 @@
             @if (count($checkResults?->storedCheckResults ?? []))
                 <dl class=" grid grid-cols-1 gap-2.5 sm:gap-3 md:gap-5 md:grid-cols-2 lg:grid-cols-3">
                     @foreach ($checkResults->storedCheckResults as $result)
-                        @ray($result)
                         <div class="flex items-start px-4 space-x-2 overflow-hidden py-5 text-opacity-0 transition transform bg-white shadow-md shadow-gray-200 dark:shadow-black/25 dark:shadow-md dark:bg-gray-800 rounded-xl sm:p-6 md:space-x-3 md:min-h-[130px] dark:border-t dark:border-gray-700">
                             <x-health-status-indicator :result="$result" />
                             <div>


### PR DESCRIPTION
When `ray` is only installed as a dev dependency and therefore we're not installing `ray` in a production environment the `@ray` directive is missing.

Just like mentioned in the [ray docs](https://spatie.be/docs/ray/v1/installation-in-your-project/laravel#installing-the-package) 😉