### PR TITLE
Allow for the Health results page theme to be overridden dynamically

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -110,7 +110,7 @@ return [
      * - dark: dark mode
      *
      * You can also override the theme dynamically.
-     * For example, in a service provider you could call:
+     * For example, in the boot() method of a service provider, you could call:
      * 
      *     \Spatie\Health\Facades\Health::setTheme('light');
      */

--- a/config/health.php
+++ b/config/health.php
@@ -108,6 +108,11 @@ return [
      *
      * - light: light mode
      * - dark: dark mode
+     *
+     * You can also override the theme dynamically.
+     * For example, in a service provider you could call:
+     * 
+     *     \Spatie\Health\Facades\Health::setTheme('light');
      */
     'theme' => 'light',
 ];

--- a/docs/viewing-results/on-a-webpage.md
+++ b/docs/viewing-results/on-a-webpage.md
@@ -21,6 +21,15 @@ There is also a dark mode available:
 
 You can enable dark mode by changing the `theme` key from `light` to `dark` in the config file.
 
+The theme set in the config will be used by default, but you can also override it in the `boot()` method of a service provider:
+
+```php
+public function boot(): void
+{
+    Health::setTheme(now()->hour >= 18 ? 'dark' : 'light');
+}
+```
+
 If you don't want these results to be public, be sure to take care of authorization yourself.
 
 ## Running the checks before rendering the page

--- a/src/Exceptions/InvalidTheme.php
+++ b/src/Exceptions/InvalidTheme.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Health\Exceptions;
+
+use Exception;
+
+class InvalidTheme extends Exception
+{
+    public static function themeIsInvalid(mixed $invalidValue): self
+    {
+        return new self("You tried to use an invalid theme, `{$invalidValue}`. Valid themes are 'light' or 'dark'.");
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -7,6 +7,7 @@ use Illuminate\Support\HtmlString;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Exceptions\DuplicateCheckNamesFound;
 use Spatie\Health\Exceptions\InvalidCheck;
+use Spatie\Health\Exceptions\InvalidTheme;
 use Spatie\Health\ResultStores\ResultStore;
 use Spatie\Health\ResultStores\ResultStores;
 
@@ -17,6 +18,8 @@ class Health
 
     /** @var array<int, string> */
     public array $inlineStylesheets = [];
+    
+    protected ?string $theme = null;
 
     /** @param array<int, Check> $checks */
     public function checks(array $checks): self
@@ -65,6 +68,27 @@ class Health
         }
 
         return new HtmlString(implode('', $assets));
+    }
+    
+    public function setTheme(?string $theme): self
+    {
+        $this->theme = $theme ?? config('health.theme');
+
+        $this->validateTheme();
+
+        return $this;
+    }
+
+    protected function validateTheme(): void
+    {
+        if (! in_array($this->theme, ['light', 'dark'], true)) {
+            throw InvalidTheme::themeIsInvalid($this->theme);
+        }
+    }
+
+    public function getTheme(): string
+    {
+        return $this->theme ?? config('health.theme');
     }
 
     /** @param array<int,mixed> $checks */

--- a/src/Http/Controllers/HealthCheckResultsController.php
+++ b/src/Http/Controllers/HealthCheckResultsController.php
@@ -25,7 +25,7 @@ class HealthCheckResultsController
             'lastRanAt' => new Carbon($checkResults?->finishedAt),
             'checkResults' => $checkResults,
             'assets' => $health->assets(),
-            'theme' => config('health.theme'),
+            'theme' => $health->getTheme(),
         ]);
     }
 }


### PR DESCRIPTION
Tools like Laravel Telescope allow users to override the theme programmatically within a service provider (e.g. `Telescope::night();`).

This is useful for users who have dynamic light/dark theme preferences on their account... but also for devs who'd just like a bit of dynamic control over light/dark modes. 😊

This backwards-compatible PR adds a new `Health::setTheme()` function. By default, the package will use the `health.theme` config setting — but it's now possible to control the theme dynamically, within the `boot()` method of a service provider, in a similar fashion to how Telescope does it.

Here's an example of how it would be used, to switch to dark mode at nighttime:

```php
class HealthServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Health::setTheme((now()->hour <= 5 || now()->hour >= 17) ? 'dark' : 'light');
    }

    // ...
```

Whilst it would be possible to apply the same time-of-day logic within the config file itself, if you call `php artisan config:cache`, this value would be cached and rendered ineffective.