### PR TITLE
Use the Logging Slack URL by default

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -66,7 +66,7 @@ return [
         ],
 
         'slack' => [
-            'webhook_url' => '',
+            'webhook_url' => config('logging.channels.slack.url', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.

--- a/docs/configuring-notifications/via-slack.md
+++ b/docs/configuring-notifications/via-slack.md
@@ -21,13 +21,13 @@ To do this you must set the `CheckFailedNotification` to use the `slack` channel
 ],
 ```
 
-In the `slack` key of the `health` config file, you can configure the various Slack settings.
+In the `slack` key of the `health` config file, you can configure the various Slack settings. By default, we use the configured Slack URL in your logging config.
 
 ```php
 // in config/health.php
 
 'slack' => [
-    'webhook_url' => '',
+    'webhook_url' => config('logging.channels.slack.url', ''),
 
     /*
      * If this is set to null the default channel of the webhook will be used.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -86,7 +86,7 @@ return [
         ],
 
         'slack' => [
-            'webhook_url' => '',
+            'webhook_url' => config('logging.channels.slack.url', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.


### PR DESCRIPTION
This PR introduces the configuration change to use the Slack URL located in the `logging.php` config by default.

