### PR TITLE
Add Cache Status

### DIFF
--- a/docs/available-checks/cache.md
+++ b/docs/available-checks/cache.md
@@ -1,0 +1,28 @@
+---
+title: Application Cache
+weight: 2
+---
+
+This check makes sure the application can connect to your cache system and read/write to the cache keys. By default, this check will make sure the `default` connection is working.
+
+## Usage
+
+Here's how you can register the check.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\CacheCheck;
+
+Health::checks([
+    CheckCheck::new(),
+]);
+```
+
+
+### Specifying the cache driver
+
+To check another cache driver, call `driver()`.
+
+```php
+CheckCheck::new()->driver('another-cache-driver'),
+```

--- a/docs/available-checks/cache.md
+++ b/docs/available-checks/cache.md
@@ -14,7 +14,7 @@ use Spatie\Health\Facades\Health;
 use Spatie\Health\Checks\Checks\CacheCheck;
 
 Health::checks([
-    CheckCheck::new(),
+    CacheCheck::new(),
 ]);
 ```
 
@@ -24,5 +24,5 @@ Health::checks([
 To check another cache driver, call `driver()`.
 
 ```php
-CheckCheck::new()->driver('another-cache-driver'),
+CacheCheck::new()->driver('another-cache-driver'),
 ```

--- a/docs/available-checks/cpu-load.md
+++ b/docs/available-checks/cpu-load.md
@@ -1,6 +1,6 @@
 ---
 title: CPU load
-weight: 2
+weight: 3
 ---
 
 This check makes sure that your CPU load isn't too high.
@@ -39,4 +39,3 @@ Health::checks([
         ->failWhenLoadIsHigherInTheLast15Minutes(1.5);
 ]);
 ```
-

--- a/docs/available-checks/db-connection.md
+++ b/docs/available-checks/db-connection.md
@@ -1,6 +1,6 @@
 ---
 title: DB connection
-weight: 2
+weight: 4
 ---
 
 This check makes sure your application can connect to a database. If the `default` database connection does not work, this check will fail.
@@ -26,4 +26,3 @@ To check another database connection, call `connectionName()`
 ```php
 DatabaseCheck::new()->connectionName('another-connection-name'),
 ```
-

--- a/docs/available-checks/debug-mode.md
+++ b/docs/available-checks/debug-mode.md
@@ -1,6 +1,6 @@
 ---
 title: Debug mode
-weight: 3
+weight: 5
 ---
 
 This check will make sure that debug mode is set to `false`. It will fail when debug mode is `true`.

--- a/docs/available-checks/environment.md
+++ b/docs/available-checks/environment.md
@@ -1,6 +1,6 @@
 ---
 title: Environment
-weight: 4
+weight: 6
 ---
 
 This check will make sure your application is running used the right environment. By default, this check will fail when the environment is not equal to `production`.

--- a/docs/available-checks/flare-error-count.md
+++ b/docs/available-checks/flare-error-count.md
@@ -1,6 +1,6 @@
 ---
 title: Flare error count
-weight: 5
+weight: 7
 ---
 
 This check will monitor the amount of errors and exceptions your application throws. For this check you'll need to have an account on [Flare](https://flareapp.io).

--- a/docs/available-checks/horizon.md
+++ b/docs/available-checks/horizon.md
@@ -1,6 +1,6 @@
 ---
 title: Horizon
-weight: 6
+weight: 8
 ---
 
 This check will make sure Horizon is running.  It will report a warning when Horizon is paused, and a failure when Horizon is not running.
@@ -17,4 +17,3 @@ Health::checks([
     HorizonCheck::new(),
 ]);
 ```
-

--- a/docs/available-checks/ping.md
+++ b/docs/available-checks/ping.md
@@ -1,6 +1,6 @@
 ---
 title: Ping
-weight: 7
+weight: 9
 ---
 
 This check will send a request to a given URL.  It will report a failure when that URL doesn't respond with a successfull response code within a second.

--- a/docs/available-checks/redis.md
+++ b/docs/available-checks/redis.md
@@ -1,6 +1,6 @@
 ---
 title: Redis
-weight: 8
+weight: 10
 ---
 
 This check will make sure Redis is running. By default, this check will make sure the `default` connection is working.

--- a/docs/available-checks/schedule.md
+++ b/docs/available-checks/schedule.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule
-weight: 9
+weight: 11
 ---
 
 This check will make sure the schedule is running. If the check detects that the schedule is not run every minute, it will fail.

--- a/docs/available-checks/used-disk-space.md
+++ b/docs/available-checks/used-disk-space.md
@@ -1,6 +1,6 @@
 ---
 title: Used disk space
-weight: 10
+weight: 12
 ---
 
 This check will monitor the percentage of available disk space.

--- a/src/Checks/Checks/CacheCheck.php
+++ b/src/Checks/Checks/CacheCheck.php
@@ -40,12 +40,12 @@ class CacheCheck extends Check
         }
     }
 
-    protected function defaultDriver()
+    protected function defaultDriver(): string
     {
         return config('cache.default', 'file');
     }
 
-    protected function pingCache($driver)
+    protected function pingCache(string $driver): bool
     {
         $payload = Str::random(5);
 

--- a/src/Checks/Checks/CacheCheck.php
+++ b/src/Checks/Checks/CacheCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Spatie\Health\Checks\Checks;
+
+use Exception;
+use function app;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Result;
+use Throwable;
+
+class CacheCheck extends Check
+{
+    protected ?string $driver = null;
+
+    public function driver(string $driver): self
+    {
+        $this->driver = $driver;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $driver = $this->driver ?? $this->defaultDriver();
+
+        $result = Result::make()->meta([
+            'driver' => $driver,
+        ]);
+
+        try {
+            $response = $this->pingCache($driver);
+
+            return $response
+                ? $result->ok()
+                : $result->failed("Could not set or retrieve an application cache value.");
+        } catch (Exception $exception) {
+            return $result->failed("An exception occurred with the application cache: `{$exception->getMessage()}`");
+        }
+    }
+
+    protected function defaultDriver()
+    {
+        return config('cache.default', 'file');
+    }
+
+    protected function pingCache($driver)
+    {
+        $payload = Str::random(5);
+
+        Cache::driver($driver)->put('laravel-health:check', $payload, 10);
+
+        return (Cache::driver($driver)->get('laravel-health:check') === $payload);
+    }
+}

--- a/tests/Checks/CacheCheckTest.php
+++ b/tests/Checks/CacheCheckTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Spatie\Health\Checks\Checks\CacheCheck;
+use Spatie\Health\Enums\Status;
+
+it('will determine that a working cache is ok', function () {
+    $result = CacheCheck::new()->run();
+
+    expect($result->status)->toBe(Status::ok());
+});
+
+
+it('will determine that a non-existing cache is not ok', function () {
+    $result = CacheCheck::new()
+        ->driver('does-not-exist')
+        ->run();
+
+    expect($result)
+        ->status->toBe(Status::failed())
+        ->getNotificationMessage()->toBe('An exception occured with the application cache: `Cache store [does-not-exist] is not defined.`');
+});

--- a/tests/Checks/CacheCheckTest.php
+++ b/tests/Checks/CacheCheckTest.php
@@ -2,6 +2,7 @@
 
 use Spatie\Health\Checks\Checks\CacheCheck;
 use Spatie\Health\Enums\Status;
+use Spatie\Health\Tests\TestClasses\FakeCacheCheck;
 
 it('will determine that a working cache is ok', function () {
     $result = CacheCheck::new()->run();
@@ -18,4 +19,14 @@ it('will determine that a non-existing cache is not ok', function () {
     expect($result)
         ->status->toBe(Status::failed())
         ->getNotificationMessage()->toBe('An exception occurred with the application cache: `Cache store [does-not-exist] is not defined.`');
+});
+
+it('will return an error when it cannot set or retrieve cache key', function () {
+    $result = FakeCacheCheck::new()
+        ->replyWith(fn () => false)
+        ->run();
+
+    expect($result)
+        ->status->toBe(Status::failed())
+        ->notificationMessage->toBe('Could not set or retrieve an application cache value.');
 });

--- a/tests/Checks/CacheCheckTest.php
+++ b/tests/Checks/CacheCheckTest.php
@@ -17,5 +17,5 @@ it('will determine that a non-existing cache is not ok', function () {
 
     expect($result)
         ->status->toBe(Status::failed())
-        ->getNotificationMessage()->toBe('An exception occured with the application cache: `Cache store [does-not-exist] is not defined.`');
+        ->getNotificationMessage()->toBe('An exception occurred with the application cache: `Cache store [does-not-exist] is not defined.`');
 });

--- a/tests/TestClasses/FakeCacheCheck.php
+++ b/tests/TestClasses/FakeCacheCheck.php
@@ -16,7 +16,7 @@ class FakeCacheCheck extends CacheCheck
         return $this;
     }
 
-    public function pingCache($driver): bool|string
+    public function pingCache(string $driver): bool
     {
         return ($this->closure)();
     }

--- a/tests/TestClasses/FakeCacheCheck.php
+++ b/tests/TestClasses/FakeCacheCheck.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Health\Tests\TestClasses;
+
+use Closure;
+use Spatie\Health\Checks\Checks\CacheCheck;
+
+class FakeCacheCheck extends CacheCheck
+{
+    protected Closure $closure;
+
+    public function replyWith(Closure $closure): self
+    {
+        $this->closure = $closure;
+
+        return $this;
+    }
+
+    public function pingCache($driver): bool|string
+    {
+        return ($this->closure)();
+    }
+}


### PR DESCRIPTION
This PR adds a check for the status of the application cache. This check makes sure the application can connect to your cache system and read/write to the cache keys.

```php
Health::checks([
    CacheCheck::new(), // uses the default connection.
    CacheCheck::new()->driver('another-cache-driver'),
]);
```