### PR TITLE
Remove url encoding from start/end date in Flare check

### DIFF
--- a/src/Checks/Checks/FlareErrorOccurrenceCountCheck.php
+++ b/src/Checks/Checks/FlareErrorOccurrenceCountCheck.php
@@ -78,8 +78,8 @@ class FlareErrorOccurrenceCountCheck extends Check
 
     protected function getFlareErrorOccurrenceCount(): int
     {
-        $startDate = urlencode(now()->subMinutes($this->periodInMinutes)->utc()->format('Y-m-d H:i:s'));
-        $endDate = urlencode(now()->utc()->format('Y-m-d H:i:s'));
+        $startDate = now()->subMinutes($this->periodInMinutes)->utc()->format('Y-m-d H:i:s');
+        $endDate = now()->utc()->format('Y-m-d H:i:s');
 
         return Http::acceptJson()
             ->get("https://flareapp.io/api/projects/{$this->flareProjectId}/error-occurrence-count", [


### PR DESCRIPTION
Due to the change in https://github.com/spatie/laravel-health/pull/8 the url-encoding is no longer necessary. Currently it silently fails (and always shows as `0`) because the Flare API validations fails on the start/end date formatting. Removing the url encoding solves that issue.