### PR TITLE
Allow for PingCheck timeout customisation

### DIFF
--- a/docs/available-checks/ping.md
+++ b/docs/available-checks/ping.md
@@ -24,5 +24,10 @@ Health::checks([
 You can use `timeout()` to set the maximum number of seconds the HTTP request should run for before the `PingCheck` fails.
 
 ```php
-    PingCheck::new()->timeout(10)
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\PingCheck;
+
+Health::checks([
+    PingCheck::new()->url('https://example.com')->timeout(2),
+]);
 ```

--- a/docs/available-checks/ping.md
+++ b/docs/available-checks/ping.md
@@ -17,3 +17,12 @@ Health::checks([
     PingCheck::new()->url('https://example.com'),
 ]);
 ```
+
+
+### Customizing the timeout
+
+You can use `timeout()` to set the maximum number of seconds the HTTP request should run for before the `PingCheck` fails.
+
+```php
+    PingCheck::new()->timeout(10)
+```

--- a/src/Checks/Checks/PingCheck.php
+++ b/src/Checks/Checks/PingCheck.php
@@ -12,10 +12,18 @@ class PingCheck extends Check
 {
     public ?string $url = null;
     public ?string $failureMessage = null;
+    public int $timeout = 1;
 
     public function url(string $url): self
     {
         $this->url = $url;
+
+        return $this;
+    }
+
+    public function timeout(int $seconds): self
+    {
+        $this->timeout = $seconds;
 
         return $this;
     }
@@ -34,7 +42,7 @@ class PingCheck extends Check
         }
 
         try {
-            if (! Http::timeout(1)->get($this->url)->successful()) {
+            if (! Http::timeout($this->timeout)->get($this->url)->successful()) {
                 return $this->failedResult();
             }
         } catch (Exception) {


### PR DESCRIPTION
I've been using `PingCheck` on my server, but keep finding I get false-positives a few times each day. Whilst 1 second is good for most sites, under certain circumstances, it should allow for customisation.

This backwards-compatible PR allows the default 1-second timeout to be overridden with `PingCheck::new()->timeout(60)`.

Docs have been updated to mention this too 👍