### PR TITLE
Bugfixes RedisCheck to take the named connection

### DIFF
--- a/src/Checks/Checks/RedisCheck.php
+++ b/src/Checks/Checks/RedisCheck.php
@@ -39,6 +39,6 @@ class RedisCheck extends Check
 
     protected function pingRedis(): bool|string
     {
-        return Redis::connection()->ping();
+        return Redis::connection($this->connectionName)->ping();
     }
 }


### PR DESCRIPTION
Bugfixes RedisCheck to take the named connection given by the connectionName parameter