### PR TITLE
Added meta tags for improved (mobile) experience

### DIFF
--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -1,5 +1,7 @@
 <html lang="en" class="{{$theme == 'dark' ? 'dark' : ''}}">
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>{{ __('health::notifications.health_results') }}</title>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     {{$assets}}


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/spatie/laravel-health/issues/54. Currently on iOS phones (confirmed in Safari) the page scales down to two columns instead of one:

![IMG_0961](https://user-images.githubusercontent.com/18613261/150211523-e035240b-dbf4-47db-bb0c-aad127a6d2d0.PNG)

By adding the viewport meta tag the page will scale down correctly on mobile devices:

![IMG_0962](https://user-images.githubusercontent.com/18613261/150211544-7c5d9bed-ca51-4f22-8d97-0de92734fb98.PNG)

I also added the charset meta tag which helps displaying special characters correctly.