### PR TITLE
feat: Improve `health:list` cli output

### DIFF
--- a/resources/views/list-cli.blade.php
+++ b/resources/views/list-cli.blade.php
@@ -1,6 +1,6 @@
 <div class="mx-2 my-1">
     @if(count($checkResults?->storedCheckResults ?? []))
-        <div class="w-full py-1 text-white bg-blue-800">
+        <div class="w-full max-w-120 mb-1 py-1 text-white bg-blue-800">
             <span class="px-2 text-left w-1/2">Laravel Health Check Results</span>
             <span class="px-2 text-right w-1/2">
                Last ran all the checks
@@ -11,24 +11,24 @@
                 @endif
             </span>
         </div>
-        <table style="box">
-            <thead>
-            <tr>
-                <td></td>
-                <td>Check</td>
-                <td>Summary</td>
-                <td>Error message</td>
-            </tr>
-            </thead>
-            @foreach($checkResults->storedCheckResults as $result)
-                <tr>
-                    <td class="{{ $color($result->status) }}">{{ ucfirst($result->status) }}</td>
-                    <td>{{ $result->label }}</td>
-                    <td>{{ $result->shortSummary }}</td>
-                    <td>{{ $result->notificationMessage }}</td>
-                </tr>
-            @endforeach
-        </table>
+        @foreach ($checkResults->storedCheckResults as $result)
+            <div class="space-x-1">
+                <span class="w-10">
+                    <b class="uppercase {{ $color($result->status) }}">
+                        {{ ucfirst($result->status) }}
+                    </b>
+                    <span class="text-gray ml-1">..........</span>
+                </span>
+                <span>{{ $result->label }}</span>
+                <span class="text-gray">›</span>
+                <span class="{{ $color($result->status) }}"> {{ $result->shortSummary }}</span>
+            </div>
+            @if ($result->notificationMessage)
+            <div class="ml-11 text-gray">
+                ⇂ {{ $result->notificationMessage }}
+            </div>
+            @endif
+        @endforeach
     @else
         <div>
             No checks have run yet...<br />

--- a/resources/views/list-cli.blade.php
+++ b/resources/views/list-cli.blade.php
@@ -17,7 +17,6 @@
                     <b class="uppercase {{ $color($result->status) }}">
                         {{ ucfirst($result->status) }}
                     </b>
-                    <span class="text-gray ml-1">..........</span>
                 </span>
                 <span>{{ $result->label }}</span>
                 <span class="text-gray">›</span>

--- a/src/Commands/ListHealthChecksCommand.php
+++ b/src/Commands/ListHealthChecksCommand.php
@@ -47,10 +47,10 @@ class ListHealthChecksCommand extends Command
         $status = Status::from($status);
 
         return match ($status) {
-            Status::ok() => 'bg-green-800',
-            Status::warning() => 'bg-yellow-800',
-            Status::skipped() => 'bg-blue-800',
-            Status::failed(), Status::crashed() => 'bg-red-800',
+            Status::ok() => 'text-green-600',
+            Status::warning() => 'text-yellow-600',
+            Status::skipped() => 'text-blue-600',
+            Status::failed(), Status::crashed() => 'text-red-600',
             default => ''
         };
     }

--- a/tests/Commands/ListChecksCommandTest.php
+++ b/tests/Commands/ListChecksCommandTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Spatie\Health\Commands\ListHealthChecksCommand;
-use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Facades\Health;
 use Spatie\Health\Tests\TestClasses\FakeUsedDiskSpaceCheck;
 use function Pest\Laravel\artisan;

--- a/tests/Commands/ListChecksCommandTest.php
+++ b/tests/Commands/ListChecksCommandTest.php
@@ -1,9 +1,10 @@
 <?php
 
-use function Pest\Laravel\artisan;
 use Spatie\Health\Commands\ListHealthChecksCommand;
+use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Facades\Health;
 use Spatie\Health\Tests\TestClasses\FakeUsedDiskSpaceCheck;
+use function Pest\Laravel\artisan;
 
 it('thrown no exceptions with no checks registered', function () {
     artisan(ListHealthChecksCommand::class)->assertSuccessful();
@@ -14,5 +15,5 @@ it('thrown no exceptions with a check registered', function () {
         FakeUsedDiskSpaceCheck::new(),
     ]);
 
-    artisan(ListHealthChecksCommand::class)->assertSuccessful();
+    artisan(ListHealthChecksCommand::class, ['--fresh' => true])->assertSuccessful();
 });


### PR DESCRIPTION
Hey guys,

This PR adds a new way to show the `health:list` output.

## Before
![image](https://user-images.githubusercontent.com/823088/151960989-0f65d40f-0c6b-4c07-964a-893e075909af.png)


## After
![image](https://user-images.githubusercontent.com/823088/151960821-de9b66ff-1a2d-4ada-ad66-0b7cdc690b2d.png)

Hope it helps,
Francisco.