### PR TITLE
Fix name of the Cache health result store parameter

### DIFF
--- a/src/ResultStores/CacheHealthResultStore.php
+++ b/src/ResultStores/CacheHealthResultStore.php
@@ -10,7 +10,7 @@ use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResults;
 class CacheHealthResultStore implements ResultStore
 {
     public function __construct(
-        public string $cacheStore = 'file',
+        public string $store = 'file',
         public string $cacheKey = 'healthStoreResults',
     ) {
     }
@@ -35,14 +35,14 @@ class CacheHealthResultStore implements ResultStore
             });
 
         cache()
-            ->store($this->cacheStore)
+            ->store($this->store)
             ->put($this->cacheKey, $report->toJson());
     }
 
     public function latestResults(): ?StoredCheckResults
     {
         $healthResultsJson = cache()
-            ->store($this->cacheStore)
+            ->store($this->store)
             ->get($this->cacheKey);
 
         if (! $healthResultsJson) {


### PR DESCRIPTION
The `CacheHealthResultStore` expects parameter named `cacheStore`, not `store`. For this reason, changing `file` to a different store did not affect the default configuration.

I had to find out why this results store is not working as expected... Hope this fix helps others save some time 😉