### PR TITLE
Add Typesense health check

### DIFF
--- a/src/Checks/Checks/TypesenseCheck.php
+++ b/src/Checks/Checks/TypesenseCheck.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Spatie\Health\Checks\Checks;
+
+use Exception;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Result;
+
+class TypesenseCheck extends Check {
+
+
+    public int $timeout = 1;
+    public string $url = 'http://127.0.0.1:8108/health';
+
+    public function timeout(int $seconds): self
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    public function url(string $url): self
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->getName();
+    }
+
+    public function run(): Result
+    {
+        try {
+            $response = Http::timeout($this->timeout)->asJson()->get($this->url);
+        } catch (Exception) {
+            return Result::make()
+                ->failed()
+                ->shortSummary('Unreachable')
+                ->notificationMessage("Could not reach {$this->url}.");
+        }
+
+        /** @phpstan-ignore-next-line */
+        if (! $response) {
+            return Result::make()
+                ->failed()
+                ->shortSummary('Did not respond')
+                ->notificationMessage("Did not get a response from {$this->url}.");
+        }
+
+        if (! Arr::has($response, 'ok')) {
+            return Result::make()
+                ->failed()
+                ->shortSummary('Invalid response')
+                ->notificationMessage("The response did not contain a `ok` key. ");
+        }
+
+        $ok = Arr::get($response, 'ok');
+
+        if ($ok !== true) {
+            return Result::make()
+                ->failed()
+                ->shortSummary('Unhealthy')
+                ->notificationMessage("The health check returned a status `Unhealthy`.");
+        }
+
+        return Result::make()
+            ->ok()
+            ->shortSummary('Healthy');
+    }
+}


### PR DESCRIPTION
Its based on the MeiliSearch check. 
Basically, we are checking the health url http://127.0.0.1:8108/health of Typesense and it should contain `{"ok": true}` if healthy, doesn't have any other type of responses.

Typesense docs: https://typesense.org/docs/guide/install-typesense.html#%F0%9F%86%97-health-check