### PR TITLE
Fix allChecksOk and containsFailingCheck behaviour

### DIFF
--- a/src/ResultStores/StoredCheckResults/StoredCheckResults.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResults.php
@@ -50,14 +50,14 @@ class StoredCheckResults
 
     public function allChecksOk(): bool
     {
-        return $this->storedCheckResults->contains(
-            fn (StoredCheckResult $line) => $line->status !== Status::ok()->value
-        );
+        return ! $this->containsFailingCheck();
     }
 
     public function containsFailingCheck(): bool
     {
-        return ! $this->allChecksOk();
+        return $this->storedCheckResults->contains(
+            fn (StoredCheckResult $line) => $line->status !== Status::ok()->value
+        );
     }
 
     /**

--- a/tests/ResultStores/StoredCheckResultsTest.php
+++ b/tests/ResultStores/StoredCheckResultsTest.php
@@ -20,6 +20,22 @@ it('has a method to check if the results contain a result with a certain status'
     expect($storedCheckResults->containsCheckWithStatus([Status::crashed(), Status::failed()]))->toBeFalse();
 });
 
+it('has a method to check if one or more checks are failing', function () {
+    $storedCheckResults = new StoredCheckResults(new DateTime(), collect([
+        makeStoredCheckResultWithStatus(Status::warning()),
+        makeStoredCheckResultWithStatus(Status::ok()),
+    ]));
+    expect($storedCheckResults->containsFailingCheck())->toBeTrue();
+});
+
+it('has a method to check if all cheks are good', function () {
+    $storedCheckResults = new StoredCheckResults(new DateTime(), collect([
+        makeStoredCheckResultWithStatus(Status::ok()),
+        makeStoredCheckResultWithStatus(Status::ok()),
+    ]));
+    expect($storedCheckResults->allChecksOk())->toBeTrue();
+});
+
 function makeStoredCheckResultWithStatus(Status $status): StoredCheckResult
 {
     return StoredCheckResult::make(

--- a/tests/ResultStores/StoredCheckResultsTest.php
+++ b/tests/ResultStores/StoredCheckResultsTest.php
@@ -28,7 +28,7 @@ it('has a method to check if one or more checks are failing', function () {
     expect($storedCheckResults->containsFailingCheck())->toBeTrue();
 });
 
-it('has a method to check if all cheks are good', function () {
+it('has a method to check if all checks are good', function () {
     $storedCheckResults = new StoredCheckResults(new DateTime(), collect([
         makeStoredCheckResultWithStatus(Status::ok()),
         makeStoredCheckResultWithStatus(Status::ok()),


### PR DESCRIPTION
The results was swapped.

When one of the checks where other then false the allChecksOk returned true and containsFailingCheck returned false.
It should behave the other way

+ Add tests for the functions