### PR TITLE
Add grouping for checks

### DIFF
--- a/docs/basic-usage/grouping-checks.md
+++ b/docs/basic-usage/grouping-checks.md
@@ -1,0 +1,40 @@
+---
+title: Grouping checks
+weight: 6
+---
+
+Sometimes you might want to run just a certain group of checks. 
+For example during the deployment, to ensure a working database connection before running the migrations but ignoring 
+the status of Horizon. 
+
+## Assigning checks to groups
+Each check can be assigned to none, one or multiple groups.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\PingCheck;
+use Spatie\Health\Checks\Checks\DatabaseCheck;
+use Spatie\Health\Checks\Checks\HorizonCheck;
+
+Health::checks([
+    PingCheck::new()->url('https://your-site.com'),
+    DatabaseCheck::new()->group('before-migration'),
+    HorizonCheck::new()->group(['after-deployment', 'other-group']),
+])
+```
+
+
+## Running checks of a certain group
+This command will only run checks assigned to the `before-migration` group, all other checks will be ignored.
+
+```bash
+php artisan health:check --fail-command-on-failing-check --group=before-migration
+```
+
+Running it without the `--group` option will run all registered checks.
+
+```bash
+php artisan health:check --fail-command-on-failing-check
+```
+
+

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -18,7 +18,7 @@ abstract class Check
     protected ?string $label = null;
 
     /**
-     * @var string[]
+     * @var array<int, string>
      */
     protected array $groups = [];
 

--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -29,7 +29,8 @@ class RunHealthChecksCommand extends Command
         $group = $this->option('group');
 
 
-        $this->info(is_string($group) ?
+        $this->info(
+            is_string($group) ?
           "Running checks for group ${group}..." :
           'Running checks...'
         );

--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -91,7 +91,9 @@ class RunHealthChecksCommand extends Command
             ->map(function (Check $check) use ($group): Result {
                 return $check->shouldRun($group)
                     ? $this->runCheck($check)
-                    : (new Result(Status::skipped()))->check($check);
+                    : (new Result(Status::skipped()))
+                        ->check($check)
+                        ->endedAt(now());
             });
     }
 

--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -35,7 +35,7 @@ class RunHealthChecksCommand extends Command
           'Running checks...'
         );
 
-        $results = $this->runChecks();
+        $results = $this->runChecks($group);
 
         if (! $this->option('do-not-store-results')) {
             $this->storeResults($results);

--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -28,11 +28,11 @@ class RunHealthChecksCommand extends Command
     {
         $group = $this->option('group');
 
-        if (is_string($group)) {
-            $this->info("Running checks for group ${group}...");
-        } else {
-            $this->info('Running checks...');
-        }
+
+        $this->info(is_string($group) ?
+          "Running checks for group ${group}..." :
+          'Running checks...'
+        );
 
         $results = $this->runChecks();
 

--- a/tests/Commands/RunChecksCommandTest.php
+++ b/tests/Commands/RunChecksCommandTest.php
@@ -142,6 +142,9 @@ it('has an option that runs only tests of a certain group', function () {
     $this->assertTrue($fakeCheck1->hasRun);
     $this->assertFalse($fakeCheck2->hasRun);
 
+    $fakeCheck1->hasRun =  false;
+
     artisan('health:check --fail-command-on-failing-check --group=group2');
+    $this->assertFalse($fakeCheck1->hasRun);
     $this->assertTrue($fakeCheck2->hasRun);
 });

--- a/tests/Commands/RunChecksCommandTest.php
+++ b/tests/Commands/RunChecksCommandTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Notification;
-use Spatie\Health\Tests\TestClasses\FakeCheck;
 use function Pest\Laravel\artisan;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Enums\Status;
@@ -9,6 +8,7 @@ use Spatie\Health\Facades\Health;
 use Spatie\Health\Models\HealthCheckResultHistoryItem;
 use Spatie\Health\Notifications\CheckFailedNotification;
 use Spatie\Health\Tests\TestClasses\CrashingCheck;
+use Spatie\Health\Tests\TestClasses\FakeCheck;
 use Spatie\Health\Tests\TestClasses\FakeUsedDiskSpaceCheck;
 
 beforeEach(function () {
@@ -144,5 +144,4 @@ it('has an option that runs only tests of a certain group', function () {
 
     artisan('health:check --fail-command-on-failing-check --group=group2');
     $this->assertTrue($fakeCheck2->hasRun);
-
 });

--- a/tests/Commands/RunChecksCommandTest.php
+++ b/tests/Commands/RunChecksCommandTest.php
@@ -124,3 +124,14 @@ it('has an option that will let the command fail when a check fails', function (
     artisan('health:check')->assertSuccessful();
     artisan('health:check --fail-command-on-failing-check')->assertFailed();
 });
+
+it('has an option that runs only tests of a certain group', function () {
+    Health::clearChecks();
+    Health::checks([
+      CrashingCheck::new()->groups('failing'),
+      FakeUsedDiskSpaceCheck::new()->groups('success')->fakeDiskUsagePercentage(0),
+    ]);
+
+    artisan('health:check --fail-command-on-failing-check --group=failing')->assertFailed();
+    artisan('health:check --fail-command-on-failing-check --group=success')->assertSuccessful();
+});

--- a/tests/Commands/RunChecksCommandTest.php
+++ b/tests/Commands/RunChecksCommandTest.php
@@ -142,7 +142,7 @@ it('has an option that runs only tests of a certain group', function () {
     $this->assertTrue($fakeCheck1->hasRun);
     $this->assertFalse($fakeCheck2->hasRun);
 
-    $fakeCheck1->hasRun =  false;
+    $fakeCheck1->hasRun = false;
 
     artisan('health:check --fail-command-on-failing-check --group=group2');
     $this->assertFalse($fakeCheck1->hasRun);

--- a/tests/TestClasses/FakeCheck.php
+++ b/tests/TestClasses/FakeCheck.php
@@ -13,7 +13,7 @@ class FakeCheck extends Check
     public function run(): Result
     {
         $this->hasRun = true;
+
         return new Result(Status::ok());
     }
-
 }

--- a/tests/TestClasses/FakeCheck.php
+++ b/tests/TestClasses/FakeCheck.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Health\Tests\TestClasses;
+
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Result;
+use Spatie\Health\Enums\Status;
+
+class FakeCheck extends Check
+{
+    public bool $hasRun = false;
+
+    public function run(): Result
+    {
+        $this->hasRun = true;
+        return new Result(Status::ok());
+    }
+
+}


### PR DESCRIPTION
This allows checks to be assigned to groups and to run checks of a single group via the `RunHealthChecksCommand`.

This should be only breaking if the `shouldRun` method of a check has been overridden in a custom check.