### PR TITLE
Add .env variable for `throttle_notifications_for_minutes`

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -54,7 +54,7 @@ return [
          * With this setting, notifications are throttled. By default, you'll
          * only get one notification per hour.
          */
-        'throttle_notifications_for_minutes' => 60,
+        'throttle_notifications_for_minutes' => env('HEALTH_THROTTLE_NOTIFICATIONS_FOR_MINUTES', 60),
 
         'mail' => [
             'to' => 'your@example.com',


### PR DESCRIPTION
Simply adds the possibility to change the throttle notification time via the .env configuration file.

This is useful if you want to set a different throttle time between the production server and the pre-production server. 