### PR TITLE
Add --fail-command-on-failing-check to health:list artisan command

### DIFF
--- a/docs/viewing-results/on-the-cli.md
+++ b/docs/viewing-results/on-the-cli.md
@@ -18,8 +18,14 @@ php artisan health:list --fresh
 ```
 
 When using the `run` option, you can also use the `do-not-store-results` and  `no-notification` options, to avoid storing results and avoid sending a notification.
-``
+
 ```bash
 php artisan health:list --fresh --do-not-store-results --no-notification
 ```
 
+By default, if some check is failing, this artisan command will return a zero exit status.
+If you want it to return a non-zero exit code, just use the `--fail-command-on-failing-check` option. 
+
+```bash
+php artisan health:list --fail-command-on-failing-check
+```

--- a/tests/Commands/ListChecksCommandTest.php
+++ b/tests/Commands/ListChecksCommandTest.php
@@ -16,3 +16,21 @@ it('thrown no exceptions with a check registered', function () {
 
     artisan(ListHealthChecksCommand::class, ['--fresh' => true])->assertSuccessful();
 });
+
+it('has an option that will let the command fail when a check fails', function () {
+    $fakeDiskSpaceCheck = FakeUsedDiskSpaceCheck::new();
+
+    Health::checks([
+        $fakeDiskSpaceCheck,
+    ]);
+
+    $fakeDiskSpaceCheck->fakeDiskUsagePercentage(0);
+    artisan('health:list')->assertSuccessful();
+    artisan('health:list --fail-command-on-failing-check')->assertSuccessful();
+
+    $fakeDiskSpaceCheck->fakeDiskUsagePercentage(100);
+
+    artisan('health:check')->assertSuccessful();
+    artisan('health:list')->assertSuccessful();
+    artisan('health:list --fail-command-on-failing-check')->assertFailed();
+});


### PR DESCRIPTION
This PR adds `--fail-command-on-failing-check` option to `health:list artisan` command, so the behaviour is similar to `health:check --fail-command-on-failing-check`.

This is my first PR ever, so I hope I made everything correctly, even if it won't be merged :)
Anyway, thanks for the opportunity to learn something new! 

