### PR TITLE
Add indexes to Eloquent health check results table

### DIFF
--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -25,5 +25,10 @@ return new class extends Migration
 
             $table->timestamps();
         });
+        
+        Schema::table($tableName, function(Blueprint $table) {
+            $table->index(['created_at']);
+            $table->index(['batch']);
+        });
     }
 };

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -27,8 +27,8 @@ return new class extends Migration
         });
         
         Schema::table($tableName, function(Blueprint $table) {
-            $table->index(['created_at']);
-            $table->index(['batch']);
+            $table->index('created_at');
+            $table->index('batch');
         });
     }
 };


### PR DESCRIPTION
I noticed frequent slow queries being logged in Telescope when running Health Checks on a busy site. This PR solves that problem by adding indexes to the `created_at` and `batch` columns.

<img width="941" alt="Screenshot 2022-03-12 at 21 30 22" src="https://user-images.githubusercontent.com/627533/158035848-a78dea64-f993-426c-922d-c72b7d21d798.png">