### PR TITLE
chore: exclude docs from package archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore
+/docs               export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
 /.php_cs.dist       export-ignore


### PR DESCRIPTION
Just went to install this and noticed the size, looks like the `docs` directory is the culprit (due to images). Excluding this from the export reduces the package size from 2.5M to 356K. 👍🏻