### PR TITLE
Don't set notification message on `ok` by default

### DIFF
--- a/src/Checks/Result.php
+++ b/src/Checks/Result.php
@@ -63,8 +63,6 @@ class Result
 
     public function ok(string $message = ''): self
     {
-        $this->notificationMessage = $message;
-
         $this->status = Status::ok();
 
         return $this;


### PR DESCRIPTION
Successful notifications shouldn't send a notification by default, you can still add one specifically if you want by calling `->notificationMessage()`