### PR TITLE
Failed Notification Cache Per Channel

### DIFF
--- a/src/Checks/Checks/ScheduleCheck.php
+++ b/src/Checks/Checks/ScheduleCheck.php
@@ -8,7 +8,7 @@ use Spatie\Health\Checks\Result;
 
 class ScheduleCheck extends Check
 {
-    protected string $cacheKey = 'health.checks.schedule.latestHeartbeatAt';
+    protected string $cacheKey = 'health:checks:schedule:latestHeartbeatAt';
 
     protected ?string $cacheStoreName = null;
 

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -39,7 +39,7 @@ class CheckFailedNotification extends Notification
             return true;
         }
 
-        $cacheKey = 'health.latestNotificationSentAt:'.$channel;
+        $cacheKey = 'health:latestNotificationSentAt:'.$channel;
 
         /** @var \Illuminate\Cache\CacheManager $cache */
         $cache = app('cache');

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -39,7 +39,7 @@ class CheckFailedNotification extends Notification
             return true;
         }
 
-        $cacheKey = 'health.latestNotificationSentAt';
+        $cacheKey = 'health.latestNotificationSentAt:'.$channel;
 
         /** @var \Illuminate\Cache\CacheManager $cache */
         $cache = app('cache');

--- a/src/ResultStores/CacheHealthResultStore.php
+++ b/src/ResultStores/CacheHealthResultStore.php
@@ -11,7 +11,7 @@ class CacheHealthResultStore implements ResultStore
 {
     public function __construct(
         public string $store = 'file',
-        public string $cacheKey = 'healthStoreResults',
+        public string $cacheKey = 'health:storeResults',
     ) {
     }
 

--- a/tests/ResultStores/CacheHealthResultStoreTest.php
+++ b/tests/ResultStores/CacheHealthResultStoreTest.php
@@ -26,7 +26,7 @@ beforeEach(function () {
 it('can cache check results', function () {
     artisan(RunHealthChecksCommand::class)->assertSuccessful();
 
-    $json = cache()->store('file')->get('healthStoreResults');
+    $json = cache()->store('file')->get('health:storeResults');
 
     assertMatchesJsonSnapshot($json);
 });


### PR DESCRIPTION
This PR solves the issue that has been raised here https://github.com/spatie/laravel-health/discussions/88

When you specify two channels on your config file only the first one will be trigger. The shouldSend method caches the healthchecks and the second time returns false because it doesn't include the channel name 