### PR TITLE
Support PHP 8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
+        php: [8.0, 8.1]
         laravel: [9.*, 8.*]
         stability: [prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spatie/enum": "^3.13",
         "spatie/laravel-package-tools": "^1.12.1",
         "spatie/regex": "^3.1.1",
-        "symfony/process": "^5.4|^6.1.3"
+        "symfony/process": "^5.4|^6.0"
     },
     "require-dev": {
         "laravel/horizon": "^5.9.10",


### PR DESCRIPTION
Hey,

This PR will add support to PHP 8.0 as it's said in [the docs](https://spatie.be/docs/laravel-health/v1/requirements). Also, will add PHP 8.0 to the tests workflow.