### PR TITLE
Slack notification fix

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -67,7 +67,7 @@ return [
         ],
 
         'slack' => [
-            'webhook_url' => config('logging.channels.slack.url', ''),
+            'webhook_url' => env('HEALTH_SLACK_WEBHOOK_URL', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.

--- a/docs/configuring-notifications/via-slack.md
+++ b/docs/configuring-notifications/via-slack.md
@@ -5,7 +5,7 @@ weight: 2
 
 When a check starts returning warnings or failures, you can get notified via mail.
 
-Do use this channel, you must install the Slack notification channel.
+To use this channel, you must install the Slack notification channel.
 
 ```bash
 composer require laravel/slack-notification-channel

--- a/docs/configuring-notifications/via-slack.md
+++ b/docs/configuring-notifications/via-slack.md
@@ -21,13 +21,13 @@ To do this you must set the `CheckFailedNotification` to use the `slack` channel
 ],
 ```
 
-In the `slack` key of the `health` config file, you can configure the various Slack settings. By default, we use the configured Slack URL in your logging config.
+In the `slack` key of the `health` config file, you can configure the various Slack settings. Set `HEALTH_SLACK_WEBHOOK_URL` env variable with a valid Slack webhook URL. You can learn how to get a webhook URL [in the Slack API docs](https://api.slack.com/messaging/webhooks).
 
 ```php
 // in config/health.php
 
 'slack' => [
-    'webhook_url' => config('logging.channels.slack.url', ''),
+    'webhook_url' => env('HEALTH_SLACK_WEBHOOK_URL', ''),
 
     /*
      * If this is set to null the default channel of the webhook will be used.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -86,7 +86,7 @@ return [
         ],
 
         'slack' => [
-            'webhook_url' => config('logging.channels.slack.url', ''),
+            'webhook_url' => env('HEALTH_SLACK_WEBHOOK_URL', ''),
 
             /*
              * If this is set to null the default channel of the webhook will be used.


### PR DESCRIPTION
This PR fixes an issue with Slack notifications. The `health.notifications.slack.webhook_url` config parameter is always empty when using the `config` helper for `logging.channels.slack.url` because it is not yet set when `health.php` is loaded. Using an env variable is safer and also adds flexibility for distinct Slack webhooks.