### PR TITLE
Add name customization info to ping.md

### DIFF
--- a/docs/available-checks/ping.md
+++ b/docs/available-checks/ping.md
@@ -31,3 +31,18 @@ Health::checks([
     PingCheck::new()->url('https://example.com')->timeout(2),
 ]);
 ```
+
+
+### Customizing the name
+
+You can use `name()` to change the title of the `PingCheck`. This is useful when you have multiple `PingCheck`s and you want to distinguish them from each other easily.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\PingCheck;
+
+Health::checks([
+    PingCheck::new()->url('https://example.com')->name('Example'),
+    PingCheck::new()->url('https://spatie.be')->name('Spatie'),
+]);
+```


### PR DESCRIPTION
I noticed there are no mentions of name customization on the `PingCheck`. I thought it's worth mentioning this in the docs since having multiple ping checks will cause a duplication exception thrown.