### PR TITLE
Fix store skipped checks results

### DIFF
--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -80,7 +80,7 @@ class RunHealthChecksCommand extends Command
             ->map(function (Check $check): Result {
                 return $check->shouldRun()
                     ? $this->runCheck($check)
-                    : (new Result(Status::skipped()))->check($check);
+                    : (new Result(Status::skipped()))->check($check)->endedAt(now());
             });
     }
 

--- a/tests/Checks/DatabaseConnectionCountCheckTest.php
+++ b/tests/Checks/DatabaseConnectionCountCheckTest.php
@@ -28,5 +28,6 @@ it('will determine that connection count is not ok if it does cross the warning 
         ->run();
 
     expect($result->status)->toBe(Status::warning());
-    expect($result->getNotificationMessage())->toContain('connections');
+
+    expect($result->getNotificationMessage())->toContain('connection');
 });

--- a/tests/ResultStores/CacheHealthResultStoreTest.php
+++ b/tests/ResultStores/CacheHealthResultStoreTest.php
@@ -1,11 +1,13 @@
 <?php
 
-use function Pest\Laravel\artisan;
 use Spatie\Health\Commands\RunHealthChecksCommand;
+use Spatie\Health\Enums\Status;
 use Spatie\Health\Facades\Health;
 use Spatie\Health\ResultStores\CacheHealthResultStore;
 use Spatie\Health\ResultStores\ResultStore;
 use Spatie\Health\Tests\TestClasses\FakeUsedDiskSpaceCheck;
+
+use function Pest\Laravel\artisan;
 use function Spatie\PestPluginTestTime\testTime;
 use function Spatie\Snapshots\assertMatchesJsonSnapshot;
 
@@ -16,8 +18,10 @@ beforeEach(function () {
         CacheHealthResultStore::class,
     ]);
 
+    $this->fakeDiskSpaceCheck = FakeUsedDiskSpaceCheck::new();
+
     Health::checks([
-        FakeUsedDiskSpaceCheck::new(),
+        $this->fakeDiskSpaceCheck,
     ]);
 
     cache()->store('file')->clear();
@@ -40,4 +44,20 @@ it('can retrieve the latest results from cache', function () {
     $report = app(ResultStore::class)->latestResults();
 
     assertMatchesJsonSnapshot($report->toJson());
+});
+
+it('can cache skipped results', function () {
+    $this
+        ->fakeDiskSpaceCheck
+        ->everyFiveMinutes();
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    testTime()->addMinutes(4);
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    $report = app(ResultStore::class)->latestResults();
+
+    expect($report->containsCheckWithStatus(Status::skipped()))->toBeTrue();
 });

--- a/tests/ResultStores/EloquentHealthResultStoreTest.php
+++ b/tests/ResultStores/EloquentHealthResultStoreTest.php
@@ -1,12 +1,14 @@
 <?php
 
-use function Pest\Laravel\artisan;
 use Spatie\Health\Commands\RunHealthChecksCommand;
+use Spatie\Health\Enums\Status;
 use Spatie\Health\Facades\Health;
 use Spatie\Health\Models\HealthCheckResultHistoryItem;
 use Spatie\Health\ResultStores\EloquentHealthResultStore;
 use Spatie\Health\ResultStores\ResultStore;
 use Spatie\Health\Tests\TestClasses\FakeUsedDiskSpaceCheck;
+
+use function Pest\Laravel\artisan;
 use function Spatie\PestPluginTestTime\testTime;
 use function Spatie\Snapshots\assertMatchesJsonSnapshot;
 
@@ -17,8 +19,10 @@ beforeEach(function () {
         EloquentHealthResultStore::class,
     ]);
 
+    $this->fakeDiskSpaceCheck = FakeUsedDiskSpaceCheck::new();
+
     Health::checks([
-        FakeUsedDiskSpaceCheck::new(),
+        $this->fakeDiskSpaceCheck,
     ]);
 });
 
@@ -37,4 +41,20 @@ it('can retrieve the latest results from json', function () {
     $report = app(ResultStore::class)->latestResults();
 
     assertMatchesJsonSnapshot($report->toJson());
+});
+
+it('can write skipped results to the database', function () {
+    $this
+        ->fakeDiskSpaceCheck
+        ->everyFiveMinutes();
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    testTime()->addMinutes(4);
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    $report = app(ResultStore::class)->latestResults();
+
+    expect($report->containsCheckWithStatus(Status::skipped()))->toBeTrue();
 });

--- a/tests/ResultStores/JsonFileHealthResultStoreTest.php
+++ b/tests/ResultStores/JsonFileHealthResultStoreTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Storage;
-use function Pest\Laravel\artisan;
 use Spatie\Health\Commands\RunHealthChecksCommand;
+use Spatie\Health\Enums\Status;
 use Spatie\Health\Facades\Health;
 use Spatie\Health\ResultStores\JsonFileHealthResultStore;
 use Spatie\Health\ResultStores\ResultStore;
 use Spatie\Health\Tests\TestClasses\FakeUsedDiskSpaceCheck;
+
+use function Pest\Laravel\artisan;
 use function Spatie\PestPluginTestTime\testTime;
 use function Spatie\Snapshots\assertMatchesJsonSnapshot;
 
@@ -24,8 +26,10 @@ beforeEach(function () {
         ],
     ]);
 
+    $this->fakeDiskSpaceCheck = FakeUsedDiskSpaceCheck::new();
+
     Health::checks([
-        FakeUsedDiskSpaceCheck::new(),
+        $this->fakeDiskSpaceCheck,
     ]);
 });
 
@@ -48,4 +52,20 @@ it('can retrieve the latest results from json', function () {
     $report = app(ResultStore::class)->latestResults();
 
     assertMatchesJsonSnapshot($report->toJson());
+});
+
+it('can write skipped results to a json file', function () {
+    $this
+        ->fakeDiskSpaceCheck
+        ->everyFiveMinutes();
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    testTime()->addMinutes(4);
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    $report = app(ResultStore::class)->latestResults();
+
+    expect($report->containsCheckWithStatus(Status::skipped()))->toBeTrue();
 });


### PR DESCRIPTION
This PR fixes an issue with storing results using `EloquentHealthResultStore` for skipped checks when a frequency method such as `->everyFiveMinutes()` is used. The `ended_at` field is required and was not set for skipped checks. Also added `ResultStores` tests for skipped checks.