### PR TITLE
Add environment constraints to checks

### DIFF
--- a/docs/basic-usage/environment-constraints.md
+++ b/docs/basic-usage/environment-constraints.md
@@ -1,0 +1,17 @@
+---
+title: Environment Constraints
+weight: 6
+---
+
+The `environments` method may be used to execute checks only on the given environments (as defined by the APP_ENV environment variable). You can specify a single environment string or an array of envrionments. Here's an example of checks with environment constraints:
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\OptimizedAppCheck;
+use Spatie\Health\Checks\Checks\ScheduleCheck;
+
+Health::checks([
+    OptimizedAppCheck::new()->environments('production'),
+    ScheduleCheck::new()->environments(['staging','production']),
+]);
+```

--- a/tests/Checks/CheckEnvironmentConstraintsTest.php
+++ b/tests/Checks/CheckEnvironmentConstraintsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use function Pest\Laravel\artisan;
+use Illuminate\Support\Facades\App;
+use Spatie\Health\Checks\Checks\DatabaseCheck;
+use Spatie\Health\Commands\RunHealthChecksCommand;
+use Spatie\Health\Enums\Status;
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Tests\TestClasses\InMemoryResultStore;
+
+beforeEach(function () {
+    config()->set('health.result_stores', InMemoryResultStore::class);
+
+    $this->check = DatabaseCheck::new()
+        ->connectionName('testing');
+
+    Health::checks([
+        $this->check,
+    ]);
+});
+
+it('will run checks only on the actual environment', function () {
+    $actualEnvironment = App::environment();
+
+    $this
+        ->check
+        ->environments($actualEnvironment);
+
+    artisan(RunHealthChecksCommand::class);
+
+    expect(InMemoryResultStore::$checkResults)->toHaveCount(1);
+    expect(InMemoryResultStore::$checkResults[0]->status)->toBe(Status::ok());
+});
+
+it('will run checks if the actual environment exists in a provided array', function () {
+    $actualEnvironment = App::environment();
+
+    $this
+        ->check
+        ->environments([$actualEnvironment, 'other-environment']);
+
+    artisan(RunHealthChecksCommand::class);
+
+    expect(InMemoryResultStore::$checkResults)->toHaveCount(1);
+    expect(InMemoryResultStore::$checkResults[0]->status)->toBe(Status::ok());
+});
+
+
+it('will skip checks for other environments', function () {
+    $this
+        ->check
+        ->environments('other-environment');
+
+    artisan(RunHealthChecksCommand::class);
+
+    expect(InMemoryResultStore::$checkResults)->toHaveCount(1);
+    expect(InMemoryResultStore::$checkResults[0]->status)->toBe(Status::skipped());
+});


### PR DESCRIPTION
This PR adds a new `environments` method that may be used to execute checks only on the given environments.