### PR TITLE
Added filesystemName to UsedDiskSpaceCheck

### DIFF
--- a/src/Checks/Checks/UsedDiskSpaceCheck.php
+++ b/src/Checks/Checks/UsedDiskSpaceCheck.php
@@ -13,6 +13,15 @@ class UsedDiskSpaceCheck extends Check
 
     protected int $errorThreshold = 90;
 
+    protected ?string $filesystemName = null;
+
+    public function filesystemName(string $filesystemName): self
+    {
+        $this->filesystemName = $filesystemName;
+
+        return $this;
+    }
+
     public function warnWhenUsedSpaceIsAbovePercentage(int $percentage): self
     {
         $this->warningThreshold = $percentage;
@@ -48,7 +57,7 @@ class UsedDiskSpaceCheck extends Check
 
     protected function getDiskUsagePercentage(): int
     {
-        $process = Process::fromShellCommandline('df -P .');
+        $process = Process::fromShellCommandline('df -P ' . ( $this->filesystemName ?: '.' ));
 
         $process->run();
 

--- a/tests/Checks/UsedDiskSpaceCheckTest.php
+++ b/tests/Checks/UsedDiskSpaceCheckTest.php
@@ -46,6 +46,16 @@ it('will return an error if the used disk space does cross the error threshold',
         ->getNotificationMessage()->toEqual('The disk is almost full (91% used).');
 });
 
+it('can set a custom filesystem name', function () {
+    $filesystem = '/mnt/temp';
+
+    $check = FakeUsedDiskSpaceCheck::new()
+        ->filesystemName('/mnt/temp');
+
+    expect($check->getFilesystemName())
+        ->toEqual($filesystem);
+});
+
 it('can report the real disk space used', function () {
     $result = UsedDiskSpaceCheck::new()->run();
 

--- a/tests/TestClasses/FakeUsedDiskSpaceCheck.php
+++ b/tests/TestClasses/FakeUsedDiskSpaceCheck.php
@@ -19,4 +19,10 @@ class FakeUsedDiskSpaceCheck extends UsedDiskSpaceCheck
     {
         return $this->fakeDiskUsagePercentage;
     }
+
+    public function getFilesystemName(): string|null
+    {
+        return $this->filesystemName;
+    }
+
 }


### PR DESCRIPTION
Thanks for the package!

On one of our projects we use attached volumes and therefore want to use the UsedDiskSpaceCheck on a custom mount/filesystem.

This PR adds a `filesystemName` property which is used in place of the default (`.`) with `df -P`.