### PR TITLE
Add `retryTimes` method

### DIFF
--- a/docs/available-checks/ping.md
+++ b/docs/available-checks/ping.md
@@ -46,3 +46,17 @@ Health::checks([
     PingCheck::new()->url('https://spatie.be')->name('Spatie'),
 ]);
 ```
+
+
+### Customizing the retry times
+
+You can use `retryTimes()` to set the number of times to retry the `PingCheck` before failing.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\PingCheck;
+
+Health::checks([
+    PingCheck::new()->url('https://example.com')->retryTimes(3),
+]);
+```

--- a/src/Checks/Checks/PingCheck.php
+++ b/src/Checks/Checks/PingCheck.php
@@ -44,7 +44,7 @@ class PingCheck extends Check
         return $this;
     }
 
-    public function retry(int $times): self
+    public function retryTimes(int $times): self
     {
         $this->retry = $times;
 

--- a/src/Checks/Checks/PingCheck.php
+++ b/src/Checks/Checks/PingCheck.php
@@ -16,7 +16,7 @@ class PingCheck extends Check
 
     public int $timeout = 1;
     
-    public int $retry = 1;
+    public int $retryTimes = 1;
 
     public string $method = 'GET';
 
@@ -46,7 +46,7 @@ class PingCheck extends Check
 
     public function retryTimes(int $times): self
     {
-        $this->retry = $times;
+        $this->retryTimes = $times;
 
         return $this;
     }
@@ -78,7 +78,7 @@ class PingCheck extends Check
         try {
             $request = Http::timeout($this->timeout)
                 ->withHeaders($this->headers)
-                ->retry($this->retry)
+                ->retry($this->retryTimes)
                 ->send($this->method, $this->url);
 
             if (! $request->successful()) {

--- a/src/Checks/Checks/PingCheck.php
+++ b/src/Checks/Checks/PingCheck.php
@@ -15,6 +15,8 @@ class PingCheck extends Check
     public ?string $failureMessage = null;
 
     public int $timeout = 1;
+    
+    public int $retry = 1;
 
     public string $method = 'GET';
 
@@ -38,6 +40,13 @@ class PingCheck extends Check
     public function method(string $method): self
     {
         $this->method = $method;
+
+        return $this;
+    }
+
+    public function retry(int $times): self
+    {
+        $this->retry = $times;
 
         return $this;
     }
@@ -67,7 +76,12 @@ class PingCheck extends Check
         }
 
         try {
-            if (! Http::timeout($this->timeout)->withHeaders($this->headers)->send($this->method, $this->url)->successful()) {
+            $request = Http::timeout($this->timeout)
+                ->withHeaders($this->headers)
+                ->retry($this->retry)
+                ->send($this->method, $this->url);
+
+            if (! $request->successful()) {
                 return $this->failedResult();
             }
         } catch (Exception) {


### PR DESCRIPTION
This PR is helpful when you want to retry the request to make sure a temporary network issue won't cause the check to fail.