### PR TITLE
Alias `health` in lieu of a separate binding

### DIFF
--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -36,8 +36,8 @@ class HealthServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->singleton(Health::class, fn () => new Health());
-        $this->app->bind('health', Health::class);
+        $this->app->singleton(Health::class);
+        $this->app->alias(Health::class, 'health');
 
         $this->app->bind(ResultStore::class, fn () => ResultStores::createFromConfig()->first());
     }


### PR DESCRIPTION
Hey 👋

This PR addresses an issue that arises when using [Laravel's Container Events](https://laravel.com/docs/9.x/container#container-events).

Given the following excerpt from an actual `ServiceProvider`:

```php
public function register(): void
{
    $this->app->afterResolving(Health::class, $this->registerChecks(...));
}

private function registerChecks(Health $health)
{
    $health->checks([
        CacheCheck::new(),
        // ommitted for brevity...
    ]);
}
```

Triggering the `health:schedule-check-heartbeat` command makes the application crash with the following exception: 

`Spatie\Health\Exceptions\DuplicateCheckNamesFound`

Digging a bit deeper reveals that the command eventually makes use of the `Health` **Facade** on [L17](https://github.com/spatie/laravel-health/blob/main/src/Commands/ScheduleCheckHeartbeatCommand.php#L17).

The problem with this, is that the `Facade` makes use of the `health` binding instead of the singleton `Health::class` binding. A kinda hidden and notorious behaviour of the `Facade` class is that it creates a completely separate service context, ie. non-singleton bindings will be treated as singletons when making use of a `Facade`.

---

**TL;DR** By aliasing `health` to `Health`, we can ensure the same instance is used across all possible use cases.

(I have also removed the `Closure` defined on L39 because the IoC container will be able to auto-wire that without any problems.)

Thanks!