### PR TITLE
Use built-in functions for disk space usage

### DIFF
--- a/src/Checks/Checks/UsedDiskSpaceCheck.php
+++ b/src/Checks/Checks/UsedDiskSpaceCheck.php
@@ -4,8 +4,6 @@ namespace Spatie\Health\Checks\Checks;
 
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
-use Spatie\Regex\Regex;
-use Symfony\Component\Process\Process;
 
 class UsedDiskSpaceCheck extends Check
 {
@@ -57,12 +55,9 @@ class UsedDiskSpaceCheck extends Check
 
     protected function getDiskUsagePercentage(): int
     {
-        $process = Process::fromShellCommandline('df -P '.($this->filesystemName ?: '.'));
+        $freeSpace = disk_free_space($this->filesystemName ?: '/');
+        $totalSpace = disk_total_space($this->filesystemName ?: '/');
 
-        $process->run();
-
-        $output = $process->getOutput();
-
-        return (int) Regex::match('/(\d*)%/', $output)->group(1);
+        return (int) 100 - ($freeSpace * 100 / $totalSpace);
     }
 }


### PR DESCRIPTION
Sometimes, on the Oh dear Application Health page, the `UsedDiskSpaceCheck` returns "Crashed" as a result check value, it's annoying, and I don't know why. I hope this PR fixes it, and I am unsure whether I am doing it right regarding the filesystem names.

I hope it passes the tests.
Cheers :)

---

### Update:
I checked with a filesystem name, and it seems it doesn't work as well:

![image_3009860196](https://user-images.githubusercontent.com/700753/199466390-1db247ad-b0c0-4ffd-8401-342ee88df1cf.jpeg)

 Any suggestions?