### PR TITLE
Minor fix fake default argument

### DIFF
--- a/src/Facades/Health.php
+++ b/src/Facades/Health.php
@@ -17,7 +17,7 @@ class Health extends Facade
     /**
      * @param array<class-string<Check>, Result|FakeValues|(Closure(Check): Result|FakeValues)> $checks
      */
-    public static function fake(array $checks): FakeHealth
+    public static function fake(array $checks = []): FakeHealth
     {
         $fake = (new FakeHealth(static::getFacadeRoot(), $checks));
 


### PR DESCRIPTION
Set default argument for the new fake function. This fixes an issue when generating helper file for autocomplete information using barryvdh/laravel-ide-helper.