### PR TITLE
Some improvements

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
         laravel: [9.*, 8.*]
         stability: [prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1]
         laravel: [9.*, 8.*]
         stability: [prefer-stable]
         include:

--- a/src/Checks/Checks/MeiliSearchCheck.php
+++ b/src/Checks/Checks/MeiliSearchCheck.php
@@ -10,9 +10,9 @@ use Spatie\Health\Checks\Result;
 
 class MeiliSearchCheck extends Check
 {
-    public int $timeout = 1;
+    protected int $timeout = 1;
 
-    public string $url = 'http://127.0.0.1:7700/health';
+    protected string $url = 'http://127.0.0.1:7700/health';
 
     public function timeout(int $seconds): self
     {

--- a/src/Checks/Checks/PingCheck.php
+++ b/src/Checks/Checks/PingCheck.php
@@ -10,18 +10,18 @@ use Spatie\Health\Exceptions\InvalidCheck;
 
 class PingCheck extends Check
 {
-    public ?string $url = null;
+    protected ?string $url = null;
 
-    public ?string $failureMessage = null;
+    protected ?string $failureMessage = null;
 
-    public int $timeout = 1;
+    protected int $timeout = 1;
 
-    public int $retryTimes = 1;
+    protected int $retryTimes = 1;
 
-    public string $method = 'GET';
+    protected string $method = 'GET';
 
     /** @var array<string, string> */
-    public array $headers = [];
+    protected array $headers = [];
 
     public function url(string $url): self
     {

--- a/src/Commands/ListHealthChecksCommand.php
+++ b/src/Commands/ListHealthChecksCommand.php
@@ -13,10 +13,10 @@ use function Termwind\render;
 
 class ListHealthChecksCommand extends Command
 {
-    public $signature = 'health:list {--fresh} {--do-not-store-results} {--no-notification}
+    protected $signature = 'health:list {--fresh} {--do-not-store-results} {--no-notification}
                          {--fail-command-on-failing-check}';
 
-    public $description = 'List all health checks';
+    protected $description = 'List all health checks';
 
     public function handle(): int
     {

--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -17,9 +17,9 @@ use Spatie\Health\ResultStores\ResultStore;
 
 class RunHealthChecksCommand extends Command
 {
-    public $signature = 'health:check {--do-not-store-results} {--no-notification} {--fail-command-on-failing-check}';
+    protected $signature = 'health:check {--do-not-store-results} {--no-notification} {--fail-command-on-failing-check}';
 
-    public $description = 'Run all health checks';
+    protected $description = 'Run all health checks';
 
     /** @var array<int, Exception> */
     protected array $thrownExceptions = [];

--- a/src/Health.php
+++ b/src/Health.php
@@ -16,7 +16,7 @@ class Health
     protected array $checks = [];
 
     /** @var array<int, string> */
-    public array $inlineStylesheets = [];
+    protected array $inlineStylesheets = [];
 
     /** @param  array<int, Check>  $checks */
     public function checks(array $checks): self

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -24,7 +24,7 @@ class HealthCheckResultHistoryItem extends Model
     use HasFactory;
     use MassPrunable;
 
-    public $guarded = [];
+    protected $guarded = [];
 
     /** @var array<string,string> */
     public $casts = [

--- a/src/ResultStores/StoredCheckResults/StoredCheckResults.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResults.php
@@ -30,11 +30,11 @@ class StoredCheckResults
     }
 
     /**
-     * @param  \DateTimeInterface|null  $finishedAt
+     * @param  DateTimeInterface|null  $finishedAt
      * @param  ?Collection<int, StoredCheckResult>  $checkResults
      */
     public function __construct(
-        DateTimeInterface $finishedAt = null,
+        ?DateTimeInterface $finishedAt = null,
         ?Collection $checkResults = null
     ) {
         $this->finishedAt = $finishedAt ?? new DateTime();

--- a/tests/Checks/HorizonCheckTest.php
+++ b/tests/Checks/HorizonCheckTest.php
@@ -11,7 +11,7 @@ it('will fail when horizon is not running', function () {
     expect($result)
         ->status->toBe(Status::failed())
         ->notificationMessage->toBe('Horizon is not running.');
-});
+})->skip(fn() => extension_loaded('redis') !== true, 'The redis extension is not loaded.');;
 
 it('will send a warning when horizon is paused', function () {
     $this->fakeHorizonStatus('paused');

--- a/tests/Checks/HorizonCheckTest.php
+++ b/tests/Checks/HorizonCheckTest.php
@@ -11,7 +11,7 @@ it('will fail when horizon is not running', function () {
     expect($result)
         ->status->toBe(Status::failed())
         ->notificationMessage->toBe('Horizon is not running.');
-})->skip(fn() => extension_loaded('redis') !== true, 'The redis extension is not loaded.');;
+})->skip(fn () => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
 
 it('will send a warning when horizon is paused', function () {
     $this->fakeHorizonStatus('paused');

--- a/tests/Checks/RedisCheckTest.php
+++ b/tests/Checks/RedisCheckTest.php
@@ -11,7 +11,7 @@ it('will return ok when redis is running', function () {
     $result = RedisCheck::new()->run();
 
     expect($result->status)->toBe(Status::ok());
-});
+})->skip(fn() => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
 
 it('will return an error when it cannot connect to Redis', function () {
     $result = FakeRedisCheck::new()

--- a/tests/Checks/RedisCheckTest.php
+++ b/tests/Checks/RedisCheckTest.php
@@ -11,7 +11,7 @@ it('will return ok when redis is running', function () {
     $result = RedisCheck::new()->run();
 
     expect($result->status)->toBe(Status::ok());
-})->skip(fn() => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
+})->skip(fn () => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
 
 it('will return an error when it cannot connect to Redis', function () {
     $result = FakeRedisCheck::new()


### PR DESCRIPTION
Hello,

I'd like to propose some improvements:
- make the constructor `finishedAt` parameter in the `StoredCheckResults` class explicitly nullable
- change the visibility to protected for some fields in the `MeiliSearchCheck`, `PingCheck` classes
- change the visibility to protected for some fields in the `ListHealthChecksCommand`, `RunHealthChecksCommand` classes
- change the visibility to protected for some fields in the `HealthCheckResultHistoryItem` class
- change the visibility to protected for some fields in the `Health` class
- add skip for Redis-dependent tests when `redis` extension is not available

I've removed the support for PHP 8.2 from this PR and moved it to #141, just not to mix up things.
