### PR TITLE
Add queue jobs check

### DIFF
--- a/docs/available-checks/queue.md
+++ b/docs/available-checks/queue.md
@@ -1,0 +1,57 @@
+---
+title: Queue
+weight: 18
+---
+
+This check will make sure that queue jobs are running. If the check detects that the queue job is not to run for more than five minutes, it will fail.
+
+This check relies on cache.
+
+## Usage
+
+First, you must register the `QueueCheck`
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\QueueCheck;
+
+Health::checks([
+    QueueCheck::new(),
+]);
+```
+
+Next, you must schedule the `Spatie\Health\Commands\QueueCheckHeartbeatCommand` to run every minute. We recommend putting this command as the very last command in your schedule.
+
+```php
+// in app/Console/Kernel.php
+use \Spatie\Health\Commands\QueueCheckHeartbeatCommand;
+
+public function schedule(Schedule $schedule) {
+    // your other commands
+
+    $schedule->command(QueueCheckHeartbeatCommand::class)->everyMinute();
+}
+```
+
+### Customize the cache store
+
+This check relies on cache to work. We highly recommend creating a [new cache store](https://laravel.com/docs/8.x/cache#configuration) and pass its name to `useCacheStore`
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\QueueCheck;
+
+Health::checks([
+    QueueCheck::new()->useCacheStore('your-custom-store-name'),
+]);
+```
+
+### Customizing the maximum heart beat age
+
+The `QueueCheckHeartbeatCommand` will write the current timestamp into the cache. The `QueueCheck` will verify that that timestamp is not over 5 minutes.
+
+Should you get too many false positives, you can change the max age of the timestamp by calling `heartbeatMaxAgeInMinutes`.
+
+```php
+QueueCheck::new()->heartbeatMaxAgeInMinutes(10),
+```

--- a/src/Checks/Checks/HeartbeatCheck.php
+++ b/src/Checks/Checks/HeartbeatCheck.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\Health\Checks\Checks;
+
+interface HeartbeatCheck
+{
+    public function getCacheStoreName(): string;
+
+    public function useCacheStore(string $cacheStoreName): self;
+
+    public function getCacheKey(): string;
+
+    public function heartbeatMaxAgeInMinutes(int $heartbeatMaxAgeInMinutes): self;
+}

--- a/src/Checks/Checks/HeartbeatCheck.php
+++ b/src/Checks/Checks/HeartbeatCheck.php
@@ -10,5 +10,7 @@ interface HeartbeatCheck
 
     public function getCacheKey(): string;
 
+    public function cacheKey(string $cacheKey): self;
+
     public function heartbeatMaxAgeInMinutes(int $heartbeatMaxAgeInMinutes): self;
 }

--- a/src/Checks/Checks/QueueCheck.php
+++ b/src/Checks/Checks/QueueCheck.php
@@ -5,14 +5,16 @@ namespace Spatie\Health\Checks\Checks;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\HasHeartbeatCheck;
 
-class ScheduleCheck extends Check implements HeartbeatCheck
+class QueueCheck extends Check implements HeartbeatCheck
 {
     use HasHeartbeatCheck;
 
     public static function new(): static
     {
         $instance = parent::new();
-        $instance->cacheKey = 'health:checks:schedule:latestHeartbeatAt';
+
+        $instance->cacheKey = 'health:checks:queue:latestHeartbeatAt';
+        $instance->heartbeatMaxAgeInMinutes = 5;
 
         return $instance;
     }

--- a/src/Checks/HasHeartbeatCheck.php
+++ b/src/Checks/HasHeartbeatCheck.php
@@ -12,11 +12,6 @@ trait HasHeartbeatCheck
 
     protected int $heartbeatMaxAgeInMinutes = 1;
 
-    public function getCacheStoreName(): string
-    {
-        return $this->cacheStoreName ?? config('cache.default');
-    }
-
     public function useCacheStore(string $cacheStoreName): self
     {
         $this->cacheStoreName = $cacheStoreName;
@@ -24,9 +19,16 @@ trait HasHeartbeatCheck
         return $this;
     }
 
-    public function getCacheKey(): string
+    public function getCacheStoreName(): string
     {
-        return $this->cacheKey;
+        return $this->cacheStoreName ?? config('cache.default');
+    }
+
+    public function cacheKey(string $cacheKey): self
+    {
+        $this->cacheKey = $cacheKey;
+
+        return $this;
     }
 
     public function heartbeatMaxAgeInMinutes(int $heartbeatMaxAgeInMinutes): self
@@ -34,6 +36,11 @@ trait HasHeartbeatCheck
         $this->heartbeatMaxAgeInMinutes = $heartbeatMaxAgeInMinutes;
 
         return $this;
+    }
+
+    public function getCacheKey(): string
+    {
+        return $this->cacheKey;
     }
 
     public function run(): Result

--- a/src/Checks/HasHeartbeatCheck.php
+++ b/src/Checks/HasHeartbeatCheck.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\Health\Checks;
+
+use Carbon\Carbon;
+
+trait HasHeartbeatCheck
+{
+    protected ?string $cacheKey = null;
+
+    protected ?string $cacheStoreName = null;
+
+    protected int $heartbeatMaxAgeInMinutes = 1;
+
+    public function getCacheStoreName(): string
+    {
+        return $this->cacheStoreName ?? config('cache.default');
+    }
+
+    public function useCacheStore(string $cacheStoreName): self
+    {
+        $this->cacheStoreName = $cacheStoreName;
+
+        return $this;
+    }
+
+    public function getCacheKey(): string
+    {
+        return $this->cacheKey;
+    }
+
+    public function heartbeatMaxAgeInMinutes(int $heartbeatMaxAgeInMinutes): self
+    {
+        $this->heartbeatMaxAgeInMinutes = $heartbeatMaxAgeInMinutes;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::make();
+
+        $lastHeartbeatTimestamp = cache()->store($this->cacheStoreName)->get($this->cacheKey);
+
+        if (! $lastHeartbeatTimestamp) {
+            return $result->failed("The {$this->getName()} check did not run yet.");
+        }
+
+        $latestHeartbeatAt = Carbon::createFromTimestamp($lastHeartbeatTimestamp);
+
+        $minutesAgo = $latestHeartbeatAt->diffInMinutes() + 1;
+
+        if ($minutesAgo > $this->heartbeatMaxAgeInMinutes) {
+            return $result->failed("The last run of the {$this->getName()} check was more than {$minutesAgo} minutes ago.");
+        }
+
+        return $result->ok();
+    }
+}

--- a/src/Commands/HeartbeatCommand.php
+++ b/src/Commands/HeartbeatCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Spatie\Health\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Checks\HeartbeatCheck;
+use Spatie\Health\Facades\Health;
+
+abstract class HeartbeatCommand extends Command
+{
+    public function handle(): int
+    {
+        $check = $this->getCheckInstance();
+
+        if (! $check) {
+            $this->error("In order to use this command, you should register the `{$this->getCheckClass()}`");
+
+            return static::FAILURE;
+        }
+
+        if (! $check instanceof HeartbeatCheck) {
+            $this->error("Class {$this->getCheckClass()} must be instance of `Spatie\Health\Checks\Checks\HeartbeatCheck`");
+
+            return static::FAILURE;
+        }
+
+        $cacheKey = $check->getCacheKey();
+
+        if (! $cacheKey) {
+            $this->error("You must set the `cacheKey` of `{$this->getCheckClass()}` to a non-empty value");
+
+            return static::FAILURE;
+        }
+
+        return $this->runHeartbeat();
+    }
+
+    public function getCheckInstance(): null|HeartbeatCheck
+    {
+        $class = $this->getCheckClass();
+
+        return Health::registeredChecks()->first(
+            fn (Check $check) => $check instanceof $class
+        );
+    }
+
+    public abstract function runHeartbeat(): int;
+
+    public abstract function getCheckClass(): string;
+}

--- a/src/Commands/QueueCheckHeartbeatCommand.php
+++ b/src/Commands/QueueCheckHeartbeatCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Health\Commands;
+
+use Spatie\Health\Checks\Checks\QueueCheck;
+use Spatie\Health\Jobs\HealthQueueJob;
+
+class QueueCheckHeartbeatCommand extends HeartbeatCommand
+{
+    protected $signature = 'health:queue-check-heartbeat';
+
+    public function runHeartbeat(): int
+    {
+        dispatch(new HealthQueueJob($this->getCheckInstance()));
+
+        return static::SUCCESS;
+    }
+
+    public function getCheckClass(): string
+    {
+        return QueueCheck::class;
+    }
+}

--- a/src/Commands/ScheduleCheckHeartbeatCommand.php
+++ b/src/Commands/ScheduleCheckHeartbeatCommand.php
@@ -2,38 +2,23 @@
 
 namespace Spatie\Health\Commands;
 
-use Illuminate\Console\Command;
-use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Checks\ScheduleCheck;
-use Spatie\Health\Facades\Health;
 
-class ScheduleCheckHeartbeatCommand extends Command
+class ScheduleCheckHeartbeatCommand extends HeartbeatCommand
 {
     protected $signature = 'health:schedule-check-heartbeat';
 
-    public function handle(): int
+    public function runHeartbeat(): int
     {
-        /** @var ScheduleCheck|null $scheduleCheck */
-        $scheduleCheck = Health::registeredChecks()->first(
-            fn (Check $check) => $check instanceof ScheduleCheck
-        );
+        $check = $this->getCheckInstance();
 
-        if (! $scheduleCheck) {
-            $this->error("In order to use this command, you should register the `Spatie\Health\Checks\Checks\ScheduleCheck`");
-
-            return static::FAILURE;
-        }
-
-        $cacheKey = $scheduleCheck->getCacheKey();
-
-        if (! $cacheKey) {
-            $this->error("You must set the `cacheKey` of `Spatie\Health\Checks\Checks\ScheduleCheck` to a non-empty value");
-
-            return static::FAILURE;
-        }
-
-        cache()->store($scheduleCheck->getCacheStoreName())->set($cacheKey, now()->timestamp);
+        cache()->store($check->getCacheStoreName())->set($check->getCacheKey(), now()->timestamp);
 
         return static::SUCCESS;
+    }
+
+    public function getCheckClass(): string
+    {
+        return ScheduleCheck::class;
     }
 }

--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\Health;
 
 use Illuminate\Support\Facades\Route;
 use Spatie\Health\Commands\ListHealthChecksCommand;
+use Spatie\Health\Commands\QueueCheckHeartbeatCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 use Spatie\Health\Components\Logo;
@@ -31,6 +32,7 @@ class HealthServiceProvider extends PackageServiceProvider
                 ListHealthChecksCommand::class,
                 RunHealthChecksCommand::class,
                 ScheduleCheckHeartbeatCommand::class,
+                QueueCheckHeartbeatCommand::class
             );
     }
 

--- a/src/Jobs/HealthQueueJob.php
+++ b/src/Jobs/HealthQueueJob.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Health\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Spatie\Health\Checks\Checks\HeartbeatCheck;
+
+class HealthQueueJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected HeartbeatCheck $queueCheck;
+
+    public function __construct(HeartbeatCheck $queueCheck)
+    {
+        $this->queueCheck = $queueCheck;
+    }
+
+    public function handle()
+    {
+        $cacheStore = $this->queueCheck->getCacheStoreName();
+        $cacheKey = $this->queueCheck->getCacheKey();
+
+        cache()->store($cacheStore)->set($cacheKey, now()->timestamp);
+    }
+}

--- a/src/Jobs/HealthQueueJob.php
+++ b/src/Jobs/HealthQueueJob.php
@@ -3,16 +3,10 @@
 namespace Spatie\Health\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Spatie\Health\Checks\Checks\HeartbeatCheck;
 
 class HealthQueueJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     protected HeartbeatCheck $queueCheck;
 
     public function __construct(HeartbeatCheck $queueCheck)
@@ -20,7 +14,7 @@ class HealthQueueJob implements ShouldQueue
         $this->queueCheck = $queueCheck;
     }
 
-    public function handle()
+    public function handle(): void
     {
         $cacheStore = $this->queueCheck->getCacheStoreName();
         $cacheKey = $this->queueCheck->getCacheKey();

--- a/tests/Checks/QueueCheckTest.php
+++ b/tests/Checks/QueueCheckTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Spatie\Health\Facades\Health;
+use function Spatie\PestPluginTestTime\testTime;
+use Spatie\Health\Checks\Checks\QueueCheck;
+use function Pest\Laravel\artisan;
+use Spatie\Health\Commands\QueueCheckHeartbeatCommand;
+use Spatie\Health\Enums\Status;
+
+beforeEach(function () {
+    $this->queueCheck = QueueCheck::new();
+
+    Health::checks([
+        QueueCheck::new(),
+    ]);
+
+    testTime()->freeze();
+});
+
+it('can check whether the queue jobs are still running', function () {
+    artisan(QueueCheckHeartbeatCommand::class)->assertSuccessful();
+
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    testTime()->addMinutes(5)->subSecond();
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    testTime()->addSecond();
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::failed());
+});
+
+it('can use custom max age of the heartbeat for queue jobs', function () {
+    $this->queueCheck->heartbeatMaxAgeInMinutes(10);
+
+    artisan(QueueCheckHeartbeatCommand::class)->assertSuccessful();
+
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    testTime()->addMinutes(10)->subSecond();
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    testTime()->addSecond();
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::failed());
+});


### PR DESCRIPTION
This PR is adding the possibility to monitor queue jobs. It is working almost the same as the scheduled check. The only difference is that this check will just dispatch a job, and detects if the queue job is run within five minutes. If not, the check will fail.

This is how it can be registered.

```php
use Spatie\Health\Facades\Health;
use Spatie\Health\Checks\Checks\QueueCheck;

Health::checks([
    QueueCheck::new(),
]);
```

And you can change the heartbeat check as you can do with the schedule check.

```php
QueueCheck::new()->heartbeatMaxAgeInMinutes(10),
```

Also, one additional cron job needs to be registered in order to dispatch the heartbeat queue job.

```php
// in app/Console/Kernel.php
use \Spatie\Health\Commands\QueueCheckHeartbeatCommand;

public function schedule(Schedule $schedule) {
    // your other commands

    $schedule->command(QueueCheckHeartbeatCommand::class)->everyMinute();
}
```

Not sure if 5 minutes would work for everyone, but let's discuss it only if this PR is acceptable to you. 🙂 