### PR TITLE
Feature/add octane check

### DIFF
--- a/src/Checks/Checks/CheckOctane.php
+++ b/src/Checks/Checks/CheckOctane.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Spatie\Health\Checks\Checks;
+
+use Laravel\Octane\RoadRunner\ServerProcessInspector as RoadRunnerServerProcessInspector;
+use Laravel\Octane\Swoole\ServerProcessInspector as SwooleServerProcessInspector;
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Result;
+
+class CheckOctane extends Check
+{
+    protected string $server = 'swoole';
+
+    protected ?string $name = 'Octane';
+
+    public function run(): Result
+    {
+        $result = Result::make();
+
+        try {
+            $server = $this->server ?: config('octane.server');
+
+            $isRunning = match ($server) {
+                'swoole' => $this->isSwooleServerRunning(),
+                'roadrunner' => $this->isRoadRunnerServerRunning(),
+                default => $this->invalidServer($result, $server),
+            };
+        } catch (\Exception) {
+            return $result->failed('Octane does not seem to be installed correctly.');
+        }
+
+        if (!$isRunning) {
+            return $result
+                ->failed('Octane Server is not Running')
+                ->shortSummary('Not Running');
+        }
+
+        return $result
+            ->ok()
+            ->shortSummary('Octane Server is Running');
+    }
+
+    public function setServer(string $server)
+    {
+        $this->server = $server;
+
+        return $this;
+    }
+
+    protected function isSwooleServerRunning()
+    {
+        return app(SwooleServerProcessInspector::class)
+            ->serverIsRunning();
+    }
+
+    /**
+     * Check if the RoadRunner server is running.
+     *
+     * @return bool
+     */
+    protected function isRoadRunnerServerRunning()
+    {
+        return app(RoadRunnerServerProcessInspector::class)
+            ->serverIsRunning();
+    }
+
+    protected function invalidServer(Result $result, string $server): Result
+    {
+        return $result
+            ->failed('Octane Server is not valid')
+            ->shortSummary('Not valid');
+    }
+}

--- a/tests/Checks/OctaneCheckTest.php
+++ b/tests/Checks/OctaneCheckTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\Health\Tests\Checks;
+
+use Spatie\Health\Checks\Checks\CheckOctane;
+use Spatie\Health\Enums\Status;
+
+it('will fail when octane is not running', function () {
+    $result = CheckOctane::new()->run();
+
+    expect($result)
+        ->status->toBe(Status::failed())
+        ->notificationMessage->toBe('Octane Server is not Running');
+})->skip(fn () => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
+
+it('will determine that a running octane is ok', function () {
+    $this->fakeOctaneStatus('running');
+
+    $result = CheckOctane::new()->run();
+
+    expect($result)->status->toBe(Status::ok());
+});

--- a/tests/Checks/OctaneCheckTest.php
+++ b/tests/Checks/OctaneCheckTest.php
@@ -12,11 +12,3 @@ it('will fail when octane is not installed', function () {
         ->status->toBe(Status::failed())
         ->notificationMessage->toBe('Octane does not seem to be installed correctly.');
 })->skip(fn () => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
-
-it('will determine that a running octane is ok', function () {
-    $this->fakeOctaneStatus('running');
-
-    $result = CheckOctane::new()->run();
-
-    expect($result)->status->toBe(Status::ok());
-});

--- a/tests/Checks/OctaneCheckTest.php
+++ b/tests/Checks/OctaneCheckTest.php
@@ -5,12 +5,12 @@ namespace Spatie\Health\Tests\Checks;
 use Spatie\Health\Checks\Checks\CheckOctane;
 use Spatie\Health\Enums\Status;
 
-it('will fail when octane is not running', function () {
+it('will fail when octane is not installed', function () {
     $result = CheckOctane::new()->run();
 
     expect($result)
         ->status->toBe(Status::failed())
-        ->notificationMessage->toBe('Octane Server is not Running');
+        ->notificationMessage->toBe('Octane does not seem to be installed correctly.');
 })->skip(fn () => extension_loaded('redis') !== true, 'The redis extension is not loaded.');
 
 it('will determine that a running octane is ok', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Laravel\Horizon\HorizonServiceProvider;
-use Laravel\Octane\Swoole\ServerProcessInspector;
 use Mockery;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Health\HealthServiceProvider;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,18 +53,6 @@ class TestCase extends Orchestra
         $this->app->instance(MasterSupervisorRepository::class, $masters);
     }
 
-    protected function fakeOctaneStatus(string $status)
-    {
-        $masters = Mockery::mock(ServerProcessInspector::class);
-        $masters->shouldReceive('all')->andReturn([
-            (object) [
-                'status' => $status,
-            ]
-        ]);
-
-        $this->app->instance(ServerProcessInspector::class, $masters);
-    }
-
     public function refreshServiceProvider(): void
     {
         (new HealthServiceProvider($this->app))->packageBooted();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,7 @@ use Laravel\Horizon\HorizonServiceProvider;
 use Mockery;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Health\HealthServiceProvider;
+use Laravel\Octane\Swoole\ServerProcessInspector;
 
 class TestCase extends Orchestra
 {
@@ -50,6 +51,21 @@ class TestCase extends Orchestra
         ]);
 
         $this->app->instance(MasterSupervisorRepository::class, $masters);
+    }
+
+    protected function fakeOctaneStatus(string $status)
+    {
+        $masters = Mockery::mock(ServerProcessInspector::class);
+        $masters->shouldReceive('all')->andReturn([
+            (object) [
+                'status' => $status,
+            ],
+            (object) [
+                'status' => $status,
+            ],
+        ]);
+
+        $this->app->instance(ServerProcessInspector::class, $masters);
     }
 
     public function refreshServiceProvider(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,10 +59,7 @@ class TestCase extends Orchestra
         $masters->shouldReceive('all')->andReturn([
             (object) [
                 'status' => $status,
-            ],
-            (object) [
-                'status' => $status,
-            ],
+            ]
         ]);
 
         $this->app->instance(ServerProcessInspector::class, $masters);


### PR DESCRIPTION
check octane status
```
use Spatie\Health\Facades\Health;
use Spatie\Health\Checks\Checks\CheckOctane;

Health::checks([
    CheckOctane::new()
]);
```
by default server is swoole, you can set server from outside

```
use Spatie\Health\Facades\Health;
use Spatie\Health\Checks\Checks\CheckOctane;

Health::checks([
    CheckOctane::new()->setServer('roadrunner')
]);
```