### PR TITLE
Fix empty output when running `artisan health:list --fresh`

### DIFF
--- a/src/Commands/ListHealthChecksCommand.php
+++ b/src/Commands/ListHealthChecksCommand.php
@@ -36,6 +36,7 @@ class ListHealthChecksCommand extends Command
 
         $checkResults = $resultStore->latestResults();
 
+        renderUsing($this->output);
         render(view('health::list-cli', [
             'lastRanAt' => new Carbon($checkResults?->finishedAt),
             'checkResults' => $checkResults,

--- a/src/Commands/ListHealthChecksCommand.php
+++ b/src/Commands/ListHealthChecksCommand.php
@@ -10,6 +10,7 @@ use Spatie\Health\ResultStores\ResultStore;
 use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResult;
 use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResults;
 use function Termwind\render;
+use function Termwind\renderUsing;
 
 class ListHealthChecksCommand extends Command
 {


### PR DESCRIPTION
So, I am having this issue where the command `artisan health:list --fresh` has an empty output. 

It happens because Termwind has an static variable `$renderer` for it's output and when an Artisan call is made with a command that also uses Termwind this static variable is updated to use `BufferedOutput` instead of the default `ConsoleOutput`.

I could not figure an easy fix for the Termwind project so I'm creating this PR here in order to at least mitigate this issue.