### PR TITLE
Add redis memory usage check

### DIFF
--- a/docs/available-checks/redis-memory-usage.md
+++ b/docs/available-checks/redis-memory-usage.md
@@ -1,0 +1,29 @@
+---
+title: Redis memory usage
+weight: 17
+---
+
+This check makes sure that your Redis is not consuming too much memory.
+
+If the memory usage is larger than the specified maximum, this check will fail.
+
+## Usage
+
+Here's how you can register the check.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\RedisMemoryUsageCheck;
+
+Health::checks([
+    RedisMemoryUsageCheck::new()->failWhenAboveMb(1000),
+]);
+```
+
+### Using different connection
+
+To customize the monitored Redis connection name, call `connectionName`.
+
+```php
+RedisMemoryUsageCheck::new()->connectionName('other-redis-connection-name'),
+```

--- a/docs/available-checks/schedule.md
+++ b/docs/available-checks/schedule.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule
-weight: 17
+weight: 18
 ---
 
 This check will make sure the schedule is running. If the check detects that the schedule is not run every minute, it will fail.

--- a/docs/available-checks/security-advisories.md
+++ b/docs/available-checks/security-advisories.md
@@ -1,6 +1,6 @@
 ---
 title: Security advisories
-weight: 18
+weight: 19
 ---
 
 This check will check if the PHP packages installed in your project have known security vulnerabilities. This check works using [Packagist's security vulnerability API](https://php.watch/articles/composer-audit#packagist-vuln-list-api). 

--- a/docs/available-checks/used-disk-space.md
+++ b/docs/available-checks/used-disk-space.md
@@ -1,6 +1,6 @@
 ---
 title: Used disk space
-weight: 19
+weight: 20
 ---
 
 This check will monitor the percentage of available disk space.

--- a/src/Checks/Checks/RedisMemoryUsageCheck.php
+++ b/src/Checks/Checks/RedisMemoryUsageCheck.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\Health\Checks\Checks;
+
+use Illuminate\Support\Facades\Redis;
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Result;
+
+class RedisMemoryUsageCheck extends Check
+{
+    protected string $connectionName = 'default';
+
+    protected float $failWhenAboveMb = 500;
+
+    public function connectionName(string $connectionName): self
+    {
+        $this->connectionName = $connectionName;
+
+        return $this;
+    }
+
+    public function failWhenAboveMb(float $errorThresholdMb): self
+    {
+        $this->failWhenAboveMb = $errorThresholdMb;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::make()->meta([
+            'connection_name' => $this->connectionName,
+        ]);
+
+        $memoryUsage = $this->getMemoryUsageInMb();
+
+        if ($memoryUsage >= $this->failWhenAboveMb) {
+            return $result->failed("Redis memory usage is {$memoryUsage} MB, which is above the threshold of {$this->failWhenAboveMb} MB.");
+        }
+
+        return $result->ok();
+    }
+
+    protected function getMemoryUsageInMb(): float
+    {
+        $memoryUsage = (int) Redis::connection($this->connectionName)->info()['Memory']['used_memory'];
+
+        return round($memoryUsage / 1024 / 1024, 2);
+    }
+}

--- a/tests/Checks/RedisMemoryUsageTest.php
+++ b/tests/Checks/RedisMemoryUsageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Health\Tests\Checks;
+
+use Spatie\Health\Checks\Result;
+use Spatie\Health\Enums\Status;
+use Spatie\Health\Tests\TestClasses\FakeRedisMemoryUsageCheck;
+
+it('will return ok if the memory usage does not cross the threshold', function () {
+    $result = FakeRedisMemoryUsageCheck::new()
+        ->fakeMemoryUsageInMb(999)
+        ->failWhenAboveMb(1000)
+        ->run();
+
+    expect($result)
+        ->toBeInstanceOf(Result::class)
+        ->status->toBe(Status::ok());
+});
+
+it('will return an error if the used memory does cross the threshold', function () {
+    $result = FakeRedisMemoryUsageCheck::new()
+        ->fakeMemoryUsageInMb(1001)
+        ->failWhenAboveMb(1000)
+        ->run();
+
+    expect($result)
+        ->toBeInstanceOf(Result::class)
+        ->status->toEqual(Status::failed())
+        ->getNotificationMessage()->toEqual('Redis memory usage is 1001 MB, which is above the threshold of 1000 MB.');
+});

--- a/tests/TestClasses/FakeRedisMemoryUsageCheck.php
+++ b/tests/TestClasses/FakeRedisMemoryUsageCheck.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\Health\Tests\TestClasses;
+
+use Spatie\Health\Checks\Checks\RedisMemoryUsageCheck;
+
+class FakeRedisMemoryUsageCheck extends RedisMemoryUsageCheck
+{
+    protected float $fakeMemoryUsageInMb;
+
+    public function fakeMemoryUsageInMb(float $fakeMemoryUsageInMb): self
+    {
+        $this->fakeMemoryUsageInMb = $fakeMemoryUsageInMb;
+
+        return $this;
+    }
+
+    public function getMemoryUsageInMb(): float
+    {
+        return $this->fakeMemoryUsageInMb;
+    }
+}


### PR DESCRIPTION
This PR adds a Redis memory usage check. It fails when memory usage reaches a certain threshold.

```php
Health::checks([
    RedisMemoryUsageCheck::new()->failWhenAboveMb(500),
]);
```