### PR TITLE
Fix `DatabaseSizeCheck` to not send notifications on passed checks

### DIFF
--- a/src/Checks/Checks/DatabaseSizeCheck.php
+++ b/src/Checks/Checks/DatabaseSizeCheck.php
@@ -29,13 +29,17 @@ class DatabaseSizeCheck extends Check
 
     public function run(): Result
     {
-        $result = Result::make();
-
         $databaseSizeInGb = $this->getDatabaseSizeInGb();
+
+        $result = Result::make()
+            ->meta([
+                'database_size' => $databaseSizeInGb,
+            ])
+            ->shortSummary("{$databaseSizeInGb} GB");
 
         return $databaseSizeInGb >= $this->failWhenSizeAboveGb
             ? $result->failed("Database size is {$databaseSizeInGb} GB, which is above the threshold of {$this->failWhenSizeAboveGb} GB")
-            : $result->ok("{$databaseSizeInGb} GB");
+            : $result->ok();
     }
 
     protected function getDefaultConnectionName(): string

--- a/tests/Checks/DatabaseSizeCheckTest.php
+++ b/tests/Checks/DatabaseSizeCheckTest.php
@@ -1,7 +1,12 @@
 <?php
 
+use Illuminate\Support\Facades\Notification;
 use Spatie\Health\Checks\Checks\DatabaseSizeCheck;
+use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Enums\Status;
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Tests\TestClasses\FakeDatabaseSizeCheck;
+use function Pest\Laravel\artisan;
 
 it('will determine that database size is ok if it does not cross the maximum', function () {
     $result = DatabaseSizeCheck::new()
@@ -20,3 +25,19 @@ it('will determine that database size is not ok if it does cross the maximum', f
 
     expect($result->status)->toBe(Status::failed());
 });
+
+it('should not send a notification on a successful check', function () {
+    registerPassingDatabaseSizeCheck();
+
+    artisan(RunHealthChecksCommand::class)->assertSuccessful();
+
+    Notification::assertNothingSent();
+});
+
+function registerPassingDatabaseSizeCheck()
+{
+    Health::checks([
+        FakeDatabaseSizeCheck::new()
+            ->fakeDatabaseSizeInGb(0.5),
+    ]);
+}

--- a/tests/TestClasses/FakeDatabaseSizeCheck.php
+++ b/tests/TestClasses/FakeDatabaseSizeCheck.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Health\Tests\TestClasses;
+
+use Closure;
+use Spatie\Health\Checks\Checks\DatabaseSizeCheck;
+
+class FakeDatabaseSizeCheck extends DatabaseSizeCheck
+{
+    protected float $fakeDatabaseSizeInGb = 0;
+
+    public function fakeDatabaseSizeInGb(float $fakeDatabaseSizeInGb): self
+    {
+        $this->fakeDatabaseSizeInGb = $fakeDatabaseSizeInGb;
+
+        return $this;
+    }
+
+    public function getDatabaseSizeInGb(): float
+    {
+        return $this->fakeDatabaseSizeInGb;
+    }
+}


### PR DESCRIPTION
The current database size usage is now included in the short summary instead of the `$result->ok()`.