### PR TITLE
Unique key based on hostname for cache check

### DIFF
--- a/src/Checks/Checks/CacheCheck.php
+++ b/src/Checks/Checks/CacheCheck.php
@@ -43,11 +43,12 @@ class CacheCheck extends Check
 
     protected function canWriteValuesToCache(string $driver): bool
     {
+        $key = 'laravel-health:check:'. $_SERVER['HOSTNAME'];
         $expectedValue = Str::random(5);
 
-        Cache::driver($driver)->put('laravel-health:check', $expectedValue, 10);
+        Cache::driver($driver)->put($key, $expectedValue, 10);
 
-        $actualValue = Cache::driver($driver)->get('laravel-health:check');
+        $actualValue = Cache::driver($driver)->get($key);
 
         return $actualValue === $expectedValue;
     }


### PR DESCRIPTION
Hello,

This pull request is related to the [discussion](https://github.com/spatie/laravel-health/discussions/163) I created about my concern about the cache check failing

I have therefore put my proposal into practice and I submit it to you.

The idea here is simple, make the cached key unique by including the hostname. This way if several servers run the check at the same time, each one writes its own entry and this avoids the check to fail.

This being my first contribution to a library, I hope I haven't missed anything, if so I will update my PR.