### PR TITLE
Fix dispatch HealthQueueJob for multiple checks

### DIFF
--- a/src/Commands/DispatchQueueCheckJobsCommand.php
+++ b/src/Commands/DispatchQueueCheckJobsCommand.php
@@ -15,12 +15,14 @@ class DispatchQueueCheckJobsCommand extends Command
     public function handle(): int
     {
         /** @var QueueCheck|null $queueCheck */
-        $queueCheck = Health::registeredChecks()->first(
+        $queueChecks = Health::registeredChecks()->filter(
             fn (Check $check) => $check instanceof QueueCheck
         );
 
-        foreach ($queueCheck->getQueues() as $queue) {
-            HealthQueueJob::dispatch($queueCheck)->onQueue($queue);
+        foreach ($queueChecks as $queueCheck) {
+            foreach ($queueCheck->getQueues() as $queue) {
+                HealthQueueJob::dispatch($queueCheck)->onQueue($queue);
+            }
         }
 
         return static::SUCCESS;

--- a/tests/Commands/DispatchQueueCheckJobsCommandTest.php
+++ b/tests/Commands/DispatchQueueCheckJobsCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Support\Facades\Bus;
+use Spatie\Health\Checks\Checks\QueueCheck;
+use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
+use Spatie\Health\Jobs\HealthQueueJob;
+use function Pest\Laravel\artisan;
+use Spatie\Health\Facades\Health;
+
+it('dispatch to default queue by default', function () {
+    Bus::fake();
+
+    Health::checks([
+        QueueCheck::new()->new(),
+    ]);
+
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    Bus::assertDispatchedTimes(HealthQueueJob::class, 1);
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'default');
+});
+
+it('dispatch to specified queue', function () {
+    Bus::fake();
+
+    Health::checks([
+        QueueCheck::new()->onQueue('queue'),
+    ]);
+
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    Bus::assertDispatchedTimes(HealthQueueJob::class, 1);
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue');
+});
+
+it('dispatch to multiple queues of single check', function () {
+    Bus::fake();
+
+    Health::checks([
+        QueueCheck::new()->onQueue(['queue1', 'queue2']),
+    ]);
+
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    Bus::assertDispatchedTimes(HealthQueueJob::class, 2);
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue1');
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue2');
+});
+
+it('dispatch multiple checks', function () {
+    Bus::fake();
+
+    Health::checks([
+        QueueCheck::new()->onQueue('queue1')->name('Queue 1'),
+        QueueCheck::new()->onQueue('queue2')->name('Queue 2'),
+    ]);
+
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    Bus::assertDispatchedTimes(HealthQueueJob::class, 2);
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue1');
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue2');
+});
+
+it('dispatch to multiple queues of multiple checks', function () {
+    Bus::fake();
+
+    Health::checks([
+        QueueCheck::new()->onQueue(['queue1', 'queue2'])->name('Queue 12'),
+        QueueCheck::new()->onQueue(['queue3', 'queue4'])->name('Queue 34'),
+    ]);
+
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    Bus::assertDispatchedTimes(HealthQueueJob::class, 4);
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue1');
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue2');
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue3');
+    Bus::assertDispatched(fn (HealthQueueJob $job) => $job->queue === 'queue4');
+});


### PR DESCRIPTION
This PR fix dispatch `HealthQueueJob` to queues, defined in multiple checks (not the first one).