### PR TITLE
Multiple servers support

### DIFF
--- a/database/factories/HealthCheckResultHistoryItemFactory.php
+++ b/database/factories/HealthCheckResultHistoryItemFactory.php
@@ -14,6 +14,7 @@ class HealthCheckResultHistoryItemFactory extends Factory
     public function definition(): array
     {
         return [
+            "server_key" => $this->faker->uuid(),
             'check_name' => $this->faker->word(),
             'check_label' => $this->faker->word(),
             'status' => $this->faker->randomElement(Status::toArray()),

--- a/database/migrations/add_server_key.php
+++ b/database/migrations/add_server_key.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Health\ResultStores\EloquentHealthResultStore;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
+
+        Schema::table($tableName, function (Blueprint $table) {
+            $table->string("server_key", 100)->nullable()->index();
+        });
+    }
+    public function down()
+    {
+        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
+
+        Schema::table($tableName, function (Blueprint $table) {
+            $table->dropColumn("server_key");
+        });
+    }
+};

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -24,7 +24,11 @@
         @if (count($checkResults?->storedCheckResults ?? []))
             <dl class=" grid grid-cols-1 gap-2.5 sm:gap-3 md:gap-5 md:grid-cols-2 lg:grid-cols-3">
                 @foreach (collect($checkResults->storedCheckResults)->groupBy(fn(Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResult $r) => $r->serverKey) as $serverKey => $results)
-                    <h1>SERVER KEY: {{ $serverKey }}</h1>
+                    <div></div>
+                    <div class="flex justify-center">
+                        <h1 class="-mt-1 font-bold text-gray-900 dark:text-white md:mt-1 md:text-l">{{ $serverKey }}</h1>
+                    </div>
+                    <div></div>
                     @foreach ($results as $result)
                         <div class="flex items-start px-4 space-x-2 overflow-hidden py-5 text-opacity-0 transition transform bg-white shadow-md shadow-gray-200 dark:shadow-black/25 dark:shadow-md dark:bg-gray-800 rounded-xl sm:p-6 md:space-x-3 md:min-h-[130px] dark:border-t dark:border-gray-700">
                             <x-health-status-indicator :result="$result" />

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -22,6 +22,7 @@
     </div>
     <div class="px-2 mt-6 md:mt-8 md:px-0">
         @if (count($checkResults?->storedCheckResults ?? []))
+
             <dl class=" grid grid-cols-1 gap-2.5 sm:gap-3 md:gap-5 md:grid-cols-2 lg:grid-cols-3">
                 @foreach (collect($checkResults->storedCheckResults)->groupBy(fn(Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResult $r) => $r->serverKey) as $serverKey => $results)
                     <div></div>

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -8,22 +8,24 @@
 </head>
 
 <body class="antialiased bg-gray-100 mt-7 md:mt-12 dark:bg-gray-900">
-    <div class="mx-auto max-w-7xl lg:px-8 sm:px-6">
-        <div class="flex flex-wrap justify-center space-y-3">
-            <h4 class="w-full text-2xl font-bold text-center text-gray-900 dark:text-white">{{ __('health::notifications.laravel_health') }}</h4>
-            <div class="flex justify-center w-full">
-                <x-health-logo/>
-            </div>
-            @if ($lastRanAt)
-                <div class="{{ $lastRanAt->diffInMinutes() > 5 ? 'text-red-400' : 'text-gray-400 dark:text-gray-500' }} text-sm text-center font-medium">
-                    {{ __('health::notifications.check_results_from') }} {{ $lastRanAt->diffForHumans() }}
-                </div>
-            @endif
+<div class="mx-auto max-w-7xl lg:px-8 sm:px-6">
+    <div class="flex flex-wrap justify-center space-y-3">
+        <h4 class="w-full text-2xl font-bold text-center text-gray-900 dark:text-white">{{ __('health::notifications.laravel_health') }}</h4>
+        <div class="flex justify-center w-full">
+            <x-health-logo/>
         </div>
-        <div class="px-2 mt-6 md:mt-8 md:px-0">
-            @if (count($checkResults?->storedCheckResults ?? []))
-                <dl class=" grid grid-cols-1 gap-2.5 sm:gap-3 md:gap-5 md:grid-cols-2 lg:grid-cols-3">
-                    @foreach ($checkResults->storedCheckResults as $result)
+        @if ($lastRanAt)
+            <div class="{{ $lastRanAt->diffInMinutes() > 5 ? 'text-red-400' : 'text-gray-400 dark:text-gray-500' }} text-sm text-center font-medium">
+                {{ __('health::notifications.check_results_from') }} {{ $lastRanAt->diffForHumans() }}
+            </div>
+        @endif
+    </div>
+    <div class="px-2 mt-6 md:mt-8 md:px-0">
+        @if (count($checkResults?->storedCheckResults ?? []))
+            <dl class=" grid grid-cols-1 gap-2.5 sm:gap-3 md:gap-5 md:grid-cols-2 lg:grid-cols-3">
+                @foreach (collect($checkResults->storedCheckResults)->groupBy(fn(Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResult $r) => $r->serverKey) as $serverKey => $results)
+                    <h1>SERVER KEY: {{ $serverKey }}</h1>
+                    @foreach ($results as $result)
                         <div class="flex items-start px-4 space-x-2 overflow-hidden py-5 text-opacity-0 transition transform bg-white shadow-md shadow-gray-200 dark:shadow-black/25 dark:shadow-md dark:bg-gray-800 rounded-xl sm:p-6 md:space-x-3 md:min-h-[130px] dark:border-t dark:border-gray-700">
                             <x-health-status-indicator :result="$result" />
                             <div>
@@ -40,9 +42,10 @@
                             </div>
                         </div>
                     @endforeach
-                </dl>
-            @endif
-        </div>
+                @endforeach
+            </dl>
+        @endif
     </div>
+</div>
 </body>
 </html>

--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -22,7 +22,6 @@
     </div>
     <div class="px-2 mt-6 md:mt-8 md:px-0">
         @if (count($checkResults?->storedCheckResults ?? []))
-
             <dl class=" grid grid-cols-1 gap-2.5 sm:gap-3 md:gap-5 md:grid-cols-2 lg:grid-cols-3">
                 @foreach (collect($checkResults->storedCheckResults)->groupBy(fn(Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResult $r) => $r->serverKey) as $serverKey => $results)
                     <div></div>

--- a/src/Health.php
+++ b/src/Health.php
@@ -12,6 +12,9 @@ use Spatie\Health\ResultStores\ResultStores;
 
 class Health
 {
+    
+    protected ?string $serverKey;
+
     /** @var array<int, Check> */
     protected array $checks = [];
 
@@ -86,5 +89,24 @@ class Health
         if ($duplicateCheckNames->isNotEmpty()) {
             throw DuplicateCheckNamesFound::make($duplicateCheckNames);
         }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getServerKey(): ?string
+    {
+        return $this->serverKey;
+    }
+
+    /**
+     * @param string|null $serverKey
+     * @return Health
+     */
+    public function setServerKey(?string $serverKey): self
+    {
+        $this->serverKey = $serverKey;
+
+        return $this;
     }
 }

--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -29,6 +29,8 @@ class HealthServiceProvider extends PackageServiceProvider
             ->hasViewComponents('health', StatusIndicator::class)
             ->hasTranslations()
             ->hasMigration('create_health_tables')
+            ->hasMigration('add_server_key')
+            ->runsMigrations()
             ->hasCommands(
                 ListHealthChecksCommand::class,
                 RunHealthChecksCommand::class,

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -10,6 +10,7 @@ use Spatie\Health\ResultStores\EloquentHealthResultStore;
 
 /**
  * @property \Carbon\Carbon $created_at
+ * @property string $server_key
  * @property string $batch
  * @property string $ended_at
  * @property string $notification_message
@@ -32,7 +33,7 @@ class HealthCheckResultHistoryItem extends Model
         'started_failing_at' => 'timestamp',
     ];
 
-    public function prunable(): Builder
+    public function prunable(): Builder 
     {
         $days = config('health.result_stores.'.EloquentHealthResultStore::class.'.keep_history_for_days') ?? 5;
 

--- a/src/ResultStores/InMemoryHealthResultStore.php
+++ b/src/ResultStores/InMemoryHealthResultStore.php
@@ -14,10 +14,12 @@ class InMemoryHealthResultStore implements ResultStore
     public function save(Collection $checkResults): void
     {
         self::$storedCheckResults = new StoredCheckResults(now());
+        $serverKey = \Spatie\Health\Facades\Health::getServerKey();
 
         $checkResults
-            ->map(function (Result $result) {
+            ->map(function (Result $result) use ($serverKey) {
                 return new StoredCheckResult(
+                    serverKey: $serverKey,
                     name: $result->check->getName(),
                     label: $result->check->getLabel(),
                     notificationMessage: $result->getNotificationMessage(),

--- a/src/ResultStores/JsonFileHealthResultStore.php
+++ b/src/ResultStores/JsonFileHealthResultStore.php
@@ -27,10 +27,12 @@ class JsonFileHealthResultStore implements ResultStore
     public function save(Collection $checkResults): void
     {
         $report = new StoredCheckResults(now());
+        $serverKey = \Spatie\Health\Facades\Health::getServerKey();
 
         $checkResults
-            ->map(function (Result $result) {
+            ->map(function (Result $result) use ($serverKey) {
                 return new StoredCheckResult(
+                    serverKey: $serverKey,
                     name: $result->check->getName(),
                     label: $result->check->getLabel(),
                     notificationMessage: $result->getNotificationMessage(),

--- a/src/ResultStores/StoredCheckResults/StoredCheckResult.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResult.php
@@ -8,6 +8,7 @@ class StoredCheckResult
      * @param  array<string, mixed>  $meta
      */
     public static function make(
+        ?string $serverKey,
         string $name,
         string $label = '',
         string $notificationMessage = '',
@@ -22,6 +23,7 @@ class StoredCheckResult
      * @param  array<string, mixed>  $meta
      */
     public function __construct(
+        public ?string $serverKey,
         public string $name,
         public string $label = '',
         public string $notificationMessage = '',
@@ -67,6 +69,7 @@ class StoredCheckResult
     public function toArray(): array
     {
         return [
+            'serverKey' => $this->serverKey,
             'name' => $this->name,
             'label' => $this->label,
             'notificationMessage' => $this->notificationMessage,


### PR DESCRIPTION
My team at PayMeService tried to use this package and really liked it, but we missed an important feature - handle multiple servers.
for example, we have 3 servers, each one of them has a dedicated beanstalk queue server.
we want to monitor all 3 queues in one unified page.

So we added server_key column to the history table, we added a setter and a getter to the Health class that might be used in implementer's service provider, and we save it in the datastores.

examples:
```
Health::setServerKey(cache()->driver("file")->rememberForever("server_id", fn () => (string) \Str::uuid()));
Health::setServerKey(config("app.machine_id"));
```

So implementers can extend controllers and do:
```
Artisan::call(RunHealthChecksCommand::class);

$checkResults = $resultStore->latestResults(false); // <---- False means get results of all servers

$res = view('health::list', [
    'lastRanAt' => new Carbon($checkResults?->finishedAt),
    'checkResults' => $checkResults,
    'assets' => $health->assets(),
    'theme' => config('health.theme'),
])->render();
```

Backward compatibility:
Default behavior is still showing only records of the same server that got the request. you must extend manually the controller to make it work with multiple server (or add default behavior config in this PR?)

What do you think?