### PR TITLE
postgresql database size fix

### DIFF
--- a/src/Support/DbConnectionInfo.php
+++ b/src/Support/DbConnectionInfo.php
@@ -62,7 +62,7 @@ class DbConnectionInfo
 
     protected function getPostgresDatabaseSize(ConnectionInterface $connection): int
     {
-        return $connection->selectOne('SELECT pg_size_pretty(pg_database_size(?)) AS size;', [
+        return $connection->selectOne('SELECT pg_database_size(?) / 1024 / 1024 AS size;', [
             $connection->getDatabaseName(),
         ])->size;
     }


### PR DESCRIPTION
pg_size_pretty returns prettified string instead of the number, like 123 MB. 