### PR TITLE
Make it possible to ignore fails for simple health check endpoint

### DIFF
--- a/database/factories/HealthCheckResultHistoryItemFactory.php
+++ b/database/factories/HealthCheckResultHistoryItemFactory.php
@@ -21,6 +21,7 @@ class HealthCheckResultHistoryItemFactory extends Factory
             'short_summary' => $this->faker->sentences(asText: true),
             'meta' => [],
             'batch' => (string) Str::uuid(),
+            'ignore_fail' => $this->faker->boolean(),
             'ended_at' => now(),
         ];
     }

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -10,7 +10,6 @@ return new class extends Migration
     public function up()
     {
         $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
-    
         Schema::create($tableName, function (Blueprint $table) {
             $table->id();
 
@@ -19,13 +18,13 @@ return new class extends Migration
             $table->string('status');
             $table->text('notification_message')->nullable();
             $table->string('short_summary')->nullable();
+            $table->bool('ignore_fail');
             $table->json('meta');
             $table->timestamp('ended_at');
             $table->uuid('batch');
 
             $table->timestamps();
         });
-        
         Schema::table($tableName, function(Blueprint $table) {
             $table->index('created_at');
             $table->index('batch');

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -20,6 +20,8 @@ abstract class Check
 
     protected bool $shouldRun = true;
 
+    public bool $ignoreFail = false;
+
     public function __construct()
     {
     }
@@ -71,7 +73,7 @@ abstract class Check
 
     public function shouldRun(): bool
     {
-        if (! $this->shouldRun) {
+        if (!$this->shouldRun) {
             return false;
         }
 
@@ -89,7 +91,7 @@ abstract class Check
 
     public function unless(bool $condition)
     {
-        $this->shouldRun = ! $condition;
+        $this->shouldRun = !$condition;
 
         return $this;
     }
@@ -103,5 +105,12 @@ abstract class Check
 
     public function onTerminate(mixed $request, mixed $response): void
     {
+    }
+
+    public function ignoreFail()
+    {
+        $this->ignoreFail = true;
+
+        return $this;
     }
 }

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -73,7 +73,7 @@ abstract class Check
 
     public function shouldRun(): bool
     {
-        if (!$this->shouldRun) {
+        if (! $this->shouldRun) {
             return false;
         }
 
@@ -91,7 +91,7 @@ abstract class Check
 
     public function unless(bool $condition)
     {
-        $this->shouldRun = !$condition;
+        $this->shouldRun = ! $condition;
 
         return $this;
     }

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -11,6 +11,7 @@ use Spatie\Health\ResultStores\EloquentHealthResultStore;
 /**
  * @property \Carbon\Carbon $created_at
  * @property string $batch
+ * @property boolean $ignore_fail
  * @property string $ended_at
  * @property string $notification_message
  * @property string $short_summary
@@ -28,6 +29,7 @@ class HealthCheckResultHistoryItem extends Model
 
     /** @var array<string,string> */
     public $casts = [
+        'ignore_fail' => 'boolean',
         'meta' => 'array',
         'started_failing_at' => 'timestamp',
     ];

--- a/src/ResultStores/EloquentHealthResultStore.php
+++ b/src/ResultStores/EloquentHealthResultStore.php
@@ -47,6 +47,7 @@ class EloquentHealthResultStore implements ResultStore
                 'short_summary' => $result->getShortSummary(),
                 'meta' => $result->meta,
                 'batch' => $batch,
+                'ignore_fail' => $result->check->ignoreFail,
                 'ended_at' => $result->ended_at,
             ]);
         });
@@ -69,6 +70,7 @@ class EloquentHealthResultStore implements ResultStore
                     notificationMessage: $historyItem->notification_message,
                     shortSummary: $historyItem->short_summary,
                     status: $historyItem->status,
+                    ignoreFail: $historyItem->ignore_fail,
                     meta: $historyItem->meta,
                 );
             });

--- a/src/ResultStores/InMemoryHealthResultStore.php
+++ b/src/ResultStores/InMemoryHealthResultStore.php
@@ -23,6 +23,7 @@ class InMemoryHealthResultStore implements ResultStore
                     notificationMessage: $result->getNotificationMessage(),
                     shortSummary: $result->getShortSummary(),
                     status: (string) $result->status->value,
+                    ignoreFail: $result->check->ignoreFail,
                     meta: $result->meta,
                 );
             })

--- a/src/ResultStores/JsonFileHealthResultStore.php
+++ b/src/ResultStores/JsonFileHealthResultStore.php
@@ -36,6 +36,7 @@ class JsonFileHealthResultStore implements ResultStore
                     notificationMessage: $result->getNotificationMessage(),
                     shortSummary: $result->getShortSummary(),
                     status: (string) $result->status->value,
+                    ignoreFail: $result->check->ignoreFail,
                     meta: $result->meta,
                 );
             })

--- a/src/ResultStores/StoredCheckResults/StoredCheckResult.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResult.php
@@ -13,6 +13,7 @@ class StoredCheckResult
         string $notificationMessage = '',
         string $shortSummary = '',
         string $status = '',
+        bool $ignoreFail = false,
         array $meta = [],
     ): self {
         return new self(...func_get_args());
@@ -27,6 +28,7 @@ class StoredCheckResult
         public string $notificationMessage = '',
         public string $shortSummary = '',
         public string $status = '',
+        public bool $ignoreFail = false,
         public array $meta = [],
     ) {
     }
@@ -72,6 +74,7 @@ class StoredCheckResult
             'notificationMessage' => $this->notificationMessage,
             'shortSummary' => $this->shortSummary,
             'status' => $this->status,
+            'ignoreFail' => $this->ignoreFail,
             'meta' => $this->meta,
         ];
     }

--- a/src/ResultStores/StoredCheckResults/StoredCheckResults.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResults.php
@@ -53,9 +53,15 @@ class StoredCheckResults
         return ! $this->containsFailingCheck();
     }
 
-    public function containsFailingCheck(): bool
+    public function containsFailingCheck(bool $ignoreFails = true): bool
     {
-        return $this->storedCheckResults->contains(
+        $result = $this->storedCheckResults;
+
+        if ($ignoreFails) {
+            $result = $result->where('ignoreFail', false);
+        }
+
+        return $result->contains(
             fn (StoredCheckResult $line) => $line->status !== Status::ok()->value
         );
     }


### PR DESCRIPTION
Hey guys.

I am currently using the package to check the health of my laravel application. As we run it inside a kubernetes cluster with a seperate pod for horizon and the laravel scheduler, we needed a way to still use the simple health check for the readiness probe. As we don't want to check the status of other containers by checking the main application, I implemented a way to just ignore fails for the simple health check endpoint. It will still show as down on the full status page but keeps returning 200 for the simple check.

Hopefully you like the change and will merge it, so we can just continue using spaties version of the package.

BR,
Alex