### PR TITLE
fix(ListChecksCommand): run multiple options at once

### DIFF
--- a/src/Commands/ListHealthChecksCommand.php
+++ b/src/Commands/ListHealthChecksCommand.php
@@ -24,10 +24,10 @@ class ListHealthChecksCommand extends Command
         if ($this->option('fresh')) {
             $parameters = [];
             if ($this->option('do-not-store-results')) {
-                $parameters[] = '--do-not-store-results';
+                $parameters['--do-not-store-results'] = true;
             }
             if ($this->option('no-notification')) {
-                $parameters[] = '--no-notification';
+                $parameters['--no-notification'] = true;
             }
 
             Artisan::call(RunHealthChecksCommand::class, $parameters);
@@ -62,7 +62,7 @@ class ListHealthChecksCommand extends Command
 
     protected function determineCommandResult(?StoredCheckResults $results): int
     {
-        if (! $this->option('fail-command-on-failing-check') || is_null($results)) {
+        if (!$this->option('fail-command-on-failing-check') || is_null($results)) {
             return self::SUCCESS;
         }
 

--- a/tests/Commands/ListChecksCommandTest.php
+++ b/tests/Commands/ListChecksCommandTest.php
@@ -34,3 +34,13 @@ it('has an option that will let the command fail when a check fails', function (
     artisan('health:list')->assertSuccessful();
     artisan('health:list --fail-command-on-failing-check')->assertFailed();
 });
+
+it('can use multiple options at once', function () {
+    $fakeDiskSpaceCheck = FakeUsedDiskSpaceCheck::new();
+
+    Health::checks([
+        $fakeDiskSpaceCheck,
+    ]);
+
+    artisan('health:list --fresh --do-not-store-results --no-notification')->assertSuccessful();
+});


### PR DESCRIPTION
When I ran `php artisan health:list --fresh --do-not-store-results --no-notification
` I've got the following error:

```
The "1" argument does not exist.
```

Here's a quick fix.