### PR TITLE
Round MySQL Database Size to Nearest Integer to Prevent Precision Loss

### DIFF
--- a/src/Support/DbConnectionInfo.php
+++ b/src/Support/DbConnectionInfo.php
@@ -55,7 +55,7 @@ class DbConnectionInfo
 
     protected function getMySQLDatabaseSize(ConnectionInterface $connection): int
     {
-        return $connection->selectOne('SELECT size from (SELECT table_schema "name", ROUND(SUM(data_length + index_length) / 1024 / 1024, 1) as size FROM information_schema.tables GROUP BY table_schema) alias_one where name = ?', [
+        return $connection->selectOne('SELECT size from (SELECT table_schema "name", ROUND(SUM(data_length + index_length) / 1024 / 1024) as size FROM information_schema.tables GROUP BY table_schema) alias_one where name = ?', [
             $connection->getDatabaseName(),
         ])->size;
     }


### PR DESCRIPTION
I've discovered an issue in the `getMySQLDatabaseSize()` method that can lead to PHP warnings about precision loss. Specifically, the MySQL query in this function employs the ROUND() function with one decimal place, sometimes resulting in a float. However, the function's type hint specifies an integer return type, and thus when the float is implicitly converted to an integer, PHP logs a warning about precision loss.

For example:
```shell
Implicit conversion from float-string "7.5" to int loses precision in /var/www/html/vendor/spatie/laravel-health/src/Support/DbConnectionInfo.php on line 60
```

This pull request proposes a simple but effective fix to this problem: adjusting the ROUND() function in the MySQL query to round to the nearest whole number, thereby ensuring that an integer is always returned.

### The primary change in this PR includes:

Modification of the MySQL query within `getMySQLDatabaseSize()` to round to the nearest integer instead of returning a float.
This fix will ensure that the method maintains type consistency as per its integer type hint, preventing PHP from logging precision loss warnings. It will also uphold the integrity of the Laravel Health package, ensuring that it consistently delivers reliable and error-free performance.

I've conducted thorough testing of this solution and confirmed that it resolves the issue effectively, with the function continuing to deliver the expected output.

I would be grateful if you could review this change and consider it for inclusion in the next package release.