### PR TITLE
Make Check macroable and allow chaining callables in if() and unless()

### DIFF
--- a/docs/basic-usage/conditionally-running-or-modifying-checks.md
+++ b/docs/basic-usage/conditionally-running-or-modifying-checks.md
@@ -1,0 +1,77 @@
+---
+title: Conditionally running or modifying checks
+weight: 5
+---
+
+You may need to only run specific checks on a specific environment or with a specific config
+enabled. This package provides methods to run checks only when specified conditions are met.
+
+If you would like to conditionally run a check, you can use the `if` and `unless` methods.
+For more control, you can also use callables. They are evaluated every time a health check is ran.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\DebugModeCheck;
+use Spatie\Health\Checks\Checks\RedisCheck;
+
+Health::checks([
+    DebugModeCheck::new()->unless(app()->environment('local')),
+    RedisCheck::new()->if(fn () => app(SomeHeavyService::class)->shouldCheckHealth()),
+]);
+```
+
+## Custom condition methods
+
+You may find yourself repeating conditions for multiple checks. To avoid that, 
+you can register a Laravel macro on a check with a custom condition method.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Check;
+use Spatie\Health\Checks\Checks\DebugModeCheck;
+use Spatie\Health\Checks\Checks\RedisCheck;
+
+Health::macro('ifEnvironment', fn (string|array $envs) => app()->environment($envs));
+
+Health::checks([
+    DebugModeCheck::new()->ifEnvironment('production')
+]);
+```
+
+## Chaining conditions
+
+Sometimes you need more than one condition on a check, so you may chain two or more of them
+simply by calling `if` or `unless` multiple times. They are evaluated in the order that 
+you define them.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\DebugModeCheck;
+use Spatie\Health\Checks\Checks\RedisCheck;
+
+Health::checks([
+    DebugModeCheck::new()
+        ->unless(app()->environment('local'))
+        ->if(fn () => app(SomeHeavyService::class)->shouldCheckHealth()),
+]);
+```
+
+## Modifying checks on a condition
+
+You may want to slightly change check's configuration under a specific condition. You can do
+so using `when` and `doUnless` methods. In this example, a smaller memory limit is enforced 
+on a local environment.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\RedisMemoryUsageCheck;
+
+Health::checks([
+    RedisMemoryUsageCheck::new()
+        ->failWhenAboveMb(1000)
+        ->when(
+            app()->environment('local'), 
+            fn (RedisMemoryUsageCheck $check) => $check->failWhenAboveMb(200)
+        ),
+]);
+```

--- a/docs/basic-usage/conditionally-running-or-modifying-checks.md
+++ b/docs/basic-usage/conditionally-running-or-modifying-checks.md
@@ -3,11 +3,10 @@ title: Conditionally running or modifying checks
 weight: 5
 ---
 
-You may need to only run specific checks on a specific environment or with a specific config
-enabled. This package provides methods to run checks only when specified conditions are met.
+This package provides methods to run certain checks only when specified conditions are met.
 
 If you would like to conditionally run a check, you can use the `if` and `unless` methods.
-For more control, you can also use callables. They are evaluated every time a health check is ran.
+For more control, you can also use callables. They are evaluated every time a health check is run.
 
 ```php
 use Spatie\Health\Facades\Health;

--- a/docs/viewing-results/general.md
+++ b/docs/viewing-results/general.md
@@ -22,18 +22,3 @@ Health::checks([
     UsedDiskSpaceCheck::new()->label('Disk space on main disk'),
 ]);
 ```
-
-## Running checks conditionally
-
-If you would like to conditionally run a check, you can use the `if` and `unless` methods.
-
-```php
-use Spatie\Health\Facades\Health;
-use Spatie\Health\Checks\Checks\DebugModeCheck;
-use Spatie\Health\Checks\Checks\RedisCheck;
-
-Health::checks([
-    DebugModeCheck::new()->if(app()->isProduction()),
-    RedisCheck::new()->unless(app()->environment('development')),
-]);
-```

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -77,7 +77,7 @@ abstract class Check
     public function shouldRun(): bool
     {
         foreach ($this->shouldRun as $shouldRun) {
-            $shouldRun = is_bool($shouldRun) ?: $shouldRun();
+            $shouldRun = is_callable($shouldRun) ? $shouldRun() : $shouldRun;
 
             if (!$shouldRun) {
                 return false;

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -15,7 +15,7 @@ abstract class Check
     use ManagesFrequencies;
     use Macroable;
     use Conditionable {
-        unless as whenUnless;
+        unless as doUnless;
     }
 
     protected string $expression = '* * * * *';

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -6,6 +6,7 @@ use Cron\CronExpression;
 use Illuminate\Console\Scheduling\ManagesFrequencies;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\Health\Enums\Status;
 
@@ -13,6 +14,7 @@ abstract class Check
 {
     use ManagesFrequencies;
     use Macroable;
+    use Conditionable;
 
     protected string $expression = '* * * * *';
 

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -21,9 +21,9 @@ abstract class Check
     protected ?string $label = null;
 
     /**
-     * @var bool|callable(): bool
+     * @var array<bool|callable(): bool>
      */
-    protected mixed $shouldRun = true;
+    protected array $shouldRun = [];
 
     public function __construct()
     {
@@ -76,10 +76,12 @@ abstract class Check
 
     public function shouldRun(): bool
     {
-        $shouldRun = is_callable($this->shouldRun) ? ($this->shouldRun)() : $this->shouldRun;
+        foreach ($this->shouldRun as $shouldRun) {
+            $shouldRun = is_bool($shouldRun) ?: $shouldRun();
 
-        if (! $shouldRun) {
-            return false;
+            if (!$shouldRun) {
+                return false;
+            }
         }
 
         $date = Date::now();
@@ -89,16 +91,16 @@ abstract class Check
 
     public function if(bool|callable $condition)
     {
-        $this->shouldRun = $condition;
+        $this->shouldRun[] = $condition;
 
         return $this;
     }
 
     public function unless(bool|callable $condition)
     {
-        $this->shouldRun = is_callable($condition) ?
+        $this->shouldRun[] = is_callable($condition) ?
             fn () => !$condition() :
-            $condition;
+            ! $condition;
 
         return $this;
     }

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -14,7 +14,9 @@ abstract class Check
 {
     use ManagesFrequencies;
     use Macroable;
-    use Conditionable;
+    use Conditionable {
+        unless as whenUnless;
+    }
 
     protected string $expression = '* * * * *';
 

--- a/src/Checks/Check.php
+++ b/src/Checks/Check.php
@@ -42,14 +42,14 @@ abstract class Check
         return $instance;
     }
 
-    public function name(string $name): self
+    public function name(string $name): static
     {
         $this->name = $name;
 
         return $this;
     }
 
-    public function label(string $label): self
+    public function label(string $label): static
     {
         $this->label = $label;
 

--- a/tests/HealthTest.php
+++ b/tests/HealthTest.php
@@ -28,8 +28,8 @@ it('can register checks', function () {
 it('can run checks conditionally using if method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
-        DebugModeCheck::new()->if(false),
-        DebugModeCheck::new()->if(true)->if(false),
+        DebugModeCheck::new()->name('Debug 1')->if(false),
+        DebugModeCheck::new()->name('Debug 2')->if(true)->if(false),
         EnvironmentCheck::new()->if(fn () => false),
     ]);
 
@@ -46,8 +46,8 @@ it('can run checks conditionally using if method', function () {
 
     Health::checks([
         UsedDiskSpaceCheck::new(),
-        DebugModeCheck::new()->if(true),
-        DebugModeCheck::new()->if(true)->if(true),
+        DebugModeCheck::new()->name('Debug 1')->if(true),
+        DebugModeCheck::new()->name('Debug 2')->if(true)->if(true),
         EnvironmentCheck::new()->if(fn () => true),
     ]);
 
@@ -68,8 +68,8 @@ it('can run checks conditionally using if method', function () {
 it('can run checks conditionally using unless method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
-        DebugModeCheck::new()->unless(true),
-        DebugModeCheck::new()->unless(false)->unless(true),
+        DebugModeCheck::new()->name('Debug 1')->unless(true),
+        DebugModeCheck::new()->name('Debug 2')->unless(false)->unless(true),
         EnvironmentCheck::new()->unless(fn () => true),
     ]);
 
@@ -86,8 +86,8 @@ it('can run checks conditionally using unless method', function () {
 
     Health::checks([
         UsedDiskSpaceCheck::new(),
-        DebugModeCheck::new()->unless(false),
-        DebugModeCheck::new()->unless(false)->unless(false),
+        DebugModeCheck::new()->name('Debug 1')->unless(false),
+        DebugModeCheck::new()->name('Debug 2')->unless(false)->unless(false),
         EnvironmentCheck::new()->unless(fn () => false),
     ]);
 
@@ -103,6 +103,22 @@ it('can run checks conditionally using unless method', function () {
         ->toBeInstanceOf(DebugModeCheck::class)
         ->and($checks[3])
         ->toBeInstanceOf(EnvironmentCheck::class);
+});
+
+it('can conditionally modify a check using when method', function () {
+    $check = DebugModeCheck::new()
+        ->when(true, fn (DebugModeCheck $check) => $check->name('Debug 1'))
+        ->when(false, fn (DebugModeCheck $check) => $check->name('Debug 2'));
+
+    expect($check->getName())->toBe('Debug 1');
+});
+
+it('can conditionally modify a check using doUnless method', function () {
+    $check = DebugModeCheck::new()
+        ->doUnless(false, fn (DebugModeCheck $check) => $check->name('Debug 1'))
+        ->doUnless(true, fn (DebugModeCheck $check) => $check->name('Debug 2'));
+
+    expect($check->getName())->toBe('Debug 1');
 });
 
 it('will throw an exception when duplicate checks are registered', function () {

--- a/tests/HealthTest.php
+++ b/tests/HealthTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\App;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Checks\DatabaseCheck;
 use Spatie\Health\Checks\Checks\DebugModeCheck;
+use Spatie\Health\Checks\Checks\EnvironmentCheck;
 use Spatie\Health\Checks\Checks\PingCheck;
 use Spatie\Health\Checks\Checks\UsedDiskSpaceCheck;
 use Spatie\Health\Checks\Result;
@@ -28,6 +29,7 @@ it('can run checks conditionally using if method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->if(false),
+        EnvironmentCheck::new()->if(fn () => false),
     ]);
 
     $checks = Health::registeredChecks()->filter(function (Check $check) {
@@ -44,6 +46,7 @@ it('can run checks conditionally using if method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->if(true),
+        EnvironmentCheck::new()->if(fn () => true),
     ]);
 
     $checks = Health::registeredChecks()->filter(function (Check $check) {
@@ -51,15 +54,18 @@ it('can run checks conditionally using if method', function () {
     });
 
     expect($checks)
-        ->toHaveCount(2)
+        ->toHaveCount(3)
         ->and($checks[1])
-        ->toBeInstanceOf(DebugModeCheck::class);
+        ->toBeInstanceOf(DebugModeCheck::class)
+        ->and($checks[2])
+        ->toBeInstanceOf(EnvironmentCheck::class);
 });
 
 it('can run checks conditionally using unless method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->unless(true),
+        EnvironmentCheck::new()->unless(fn () => true),
     ]);
 
     $checks = Health::registeredChecks()->filter(function (Check $check) {
@@ -76,6 +82,7 @@ it('can run checks conditionally using unless method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->unless(false),
+        EnvironmentCheck::new()->unless(fn () => false),
     ]);
 
     $checks = Health::registeredChecks()->filter(function (Check $check) {
@@ -83,9 +90,11 @@ it('can run checks conditionally using unless method', function () {
     });
 
     expect($checks)
-        ->toHaveCount(2)
+        ->toHaveCount(3)
         ->and($checks[1])
-        ->toBeInstanceOf(DebugModeCheck::class);
+        ->toBeInstanceOf(DebugModeCheck::class)
+        ->and($checks[2])
+        ->toBeInstanceOf(EnvironmentCheck::class);
 });
 
 it('will throw an exception when duplicate checks are registered', function () {

--- a/tests/HealthTest.php
+++ b/tests/HealthTest.php
@@ -29,6 +29,7 @@ it('can run checks conditionally using if method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->if(false),
+        DebugModeCheck::new()->if(true)->if(false),
         EnvironmentCheck::new()->if(fn () => false),
     ]);
 
@@ -46,6 +47,7 @@ it('can run checks conditionally using if method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->if(true),
+        DebugModeCheck::new()->if(true)->if(true),
         EnvironmentCheck::new()->if(fn () => true),
     ]);
 
@@ -54,10 +56,12 @@ it('can run checks conditionally using if method', function () {
     });
 
     expect($checks)
-        ->toHaveCount(3)
+        ->toHaveCount(4)
         ->and($checks[1])
         ->toBeInstanceOf(DebugModeCheck::class)
         ->and($checks[2])
+        ->toBeInstanceOf(DebugModeCheck::class)
+        ->and($checks[3])
         ->toBeInstanceOf(EnvironmentCheck::class);
 });
 
@@ -65,6 +69,7 @@ it('can run checks conditionally using unless method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->unless(true),
+        DebugModeCheck::new()->unless(false)->unless(true),
         EnvironmentCheck::new()->unless(fn () => true),
     ]);
 
@@ -82,6 +87,7 @@ it('can run checks conditionally using unless method', function () {
     Health::checks([
         UsedDiskSpaceCheck::new(),
         DebugModeCheck::new()->unless(false),
+        DebugModeCheck::new()->unless(false)->unless(false),
         EnvironmentCheck::new()->unless(fn () => false),
     ]);
 
@@ -90,10 +96,12 @@ it('can run checks conditionally using unless method', function () {
     });
 
     expect($checks)
-        ->toHaveCount(3)
+        ->toHaveCount(4)
         ->and($checks[1])
         ->toBeInstanceOf(DebugModeCheck::class)
         ->and($checks[2])
+        ->toBeInstanceOf(DebugModeCheck::class)
+        ->and($checks[3])
         ->toBeInstanceOf(EnvironmentCheck::class);
 });
 


### PR DESCRIPTION
This would allow adding custom health checks filtering using macros:

```
Check::macro('inProduction', function () {
    return $this->if(fn () => app()->isProduction());
});

Check::macro('inContainerTypes', function (array $types) {
    return $this->if(fn () => in_array(app()->containerType(), $types));
});

Health::checks([
    DebugCheck::new()
        ->inProduction()
        ->inContainerTypes(['app']),
]);
```