### PR TITLE
Add an alternative and more clarified method for customising the queue job time handling

### DIFF
--- a/docs/available-checks/queue.md
+++ b/docs/available-checks/queue.md
@@ -57,10 +57,10 @@ Health::checks([
 
 ### Customizing job time
 
-By default, the `QueueCheck` will fail when the job dispatched by `DispatchQueueCheckJobsCommand` isn't handled within 5 minutes. You can customize the amount of minutes using the `failWhenHealthJobTakesLongerThanMinutes` method.
+By default, the `QueueCheck` will fail when the job dispatched by `DispatchQueueCheckJobsCommand` isn't handled within 5 minutes. You can customize the amount of minutes using the `failWhenHealthJobIsNotHandledWithinMinutes` method.
 
 ```php
-QueueCheck::new()->failWhenHealthJobTakesLongerThanMinutes(10),
+QueueCheck::new()->failWhenHealthJobIsNotHandledWithinMinutes(10),
 ```
 
 ### Customize the cache store

--- a/src/Checks/Checks/QueueCheck.php
+++ b/src/Checks/Checks/QueueCheck.php
@@ -43,6 +43,11 @@ class QueueCheck extends Check
         return $this;
     }
 
+    public function failWhenHealthJobIsNotHandledWithinMinutes(int $minutes): self
+    {
+        return $this->failWhenHealthJobTakesLongerThanMinutes($minutes);
+    }
+
     public function getCacheKey(string $queue): string
     {
         return "{$this->cacheKey}.{$queue}";

--- a/tests/Checks/QueueCheckTest.php
+++ b/tests/Checks/QueueCheckTest.php
@@ -51,6 +51,23 @@ it('can use custom max age of the heartbeat for queue jobs', function () {
     expect($result->status)->toBe(Status::failed());
 });
 
+it('can use an alternative method to customise the max age of the heartbeat for queue jobs', function () {
+    $this->queueCheck->failWhenHealthJobIsNotHandledWithinMinutes(10);
+
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    testTime()->addMinutes(10)->subSecond();
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    testTime()->addSecond();
+    $result = $this->queueCheck->run();
+    expect($result->status)->toBe(Status::failed());
+});
+
 it('will fail if only one queue is not working', function () {
     Health::clearChecks();
 


### PR DESCRIPTION
I caught myself doubting when looking at the `failWhenHealthJobTakesLongerThanMinutes` method and thought that this wasn't what I was looking for. When reading the description it actually was what I was looking for. 

My doubt was mostly there because of the method name. I was looking to loosen the time for the jobs **to be handled** and not for the actual **duration** of the job. 

`failWhenHealthJobTakesLongerThanMinutes` implied to me that I would be changing a limit for the duration of the jobs and not the time until the job was handled.

I added an alternative and more clarified method that is based on how it is mentioned now in the description:  `failWhenHealthJobIsNotHandledWithinMinutes`. This method calls the existing method so it doesn't break anything for users of the `failWhenHealthJobTakesLongerThanMinutes`. I also added a similar test as the existing one and updated the docs.