### PR TITLE
Support null cache driver

### DIFF
--- a/src/Checks/Checks/CacheCheck.php
+++ b/src/Checks/Checks/CacheCheck.php
@@ -36,12 +36,12 @@ class CacheCheck extends Check
         }
     }
 
-    protected function defaultDriver(): string
+    protected function defaultDriver(): ?string
     {
         return config('cache.default', 'file');
     }
 
-    protected function canWriteValuesToCache(string $driver): bool
+    protected function canWriteValuesToCache(?string $driver): bool
     {
         $expectedValue = Str::random(5);
 


### PR DESCRIPTION
When you set the following in your `.env`

```dotenv
CACHE_DRIVER=null
```

The `\Spatie\Health\Checks\Checks\CacheCheck` will fail because of the typehints. 
`config('cache.default', 'file')` will return `null` and give an error as the typehint there is not nullable.