### PR TITLE
Fixed output of Ping on null

### DIFF
--- a/src/Checks/Checks/PingCheck.php
+++ b/src/Checks/Checks/PingCheck.php
@@ -72,7 +72,9 @@ class PingCheck extends Check
     public function run(): Result
     {
         if (is_null($this->url)) {
-            throw InvalidCheck::urlNotSet();
+            return Result::make()
+                ->failed()
+                ->shortSummary(InvalidCheck::urlNotSet()->getMessage());
         }
 
         try {


### PR DESCRIPTION
When the `->url()` is null, then the output of Ping will show "Crashed" instead of what it is actually supposed to print.

Before:
![image](https://github.com/spatie/laravel-health/assets/64212185/3ca78fc4-d376-450a-8382-10172e00ce82)

After:
![image](https://github.com/spatie/laravel-health/assets/64212185/60ea459e-4382-4822-9fac-a3637b4cdb3d)
