### PR TITLE
Update QueueCheck.php

### DIFF
--- a/src/Checks/Checks/QueueCheck.php
+++ b/src/Checks/Checks/QueueCheck.php
@@ -57,7 +57,7 @@ class QueueCheck extends Check
 
     public function getQueues(): array
     {
-        return $this->onQueues ?? [$this->getDefaultQueue(config('queue.driver'))];
+        return $this->onQueues ?? [$this->getDefaultQueue(config('queue.default'))];
     }
 
     protected function getDefaultQueue($connection)


### PR DESCRIPTION
BUG: `DispatchQueueCheckJobsCommand` is dispatching a `HealthQueueJob` Job. But as per the code in the `QueueCheck.php` file, it's taking based on the driver from the [config/queue.php](https://github.com/laravel/laravel/blob/10.x/config/queue.php#L16C6-L16C13) there is no any key named `driver`.

I have changed it to `queue.default` so as per the configuration default driver will be used.