### PR TITLE
Add Microsoft Teams notification functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Health::checks([
 ]);
 ```
 
-When the used disk space is over 70%, then a notification with a warning will be sent. If it's above 90%, you'll get an error notification. Out of the box, the package can notify you via mail and Slack.
+When the used disk space is over 70%, then a notification with a warning will be sent. If it's above 90%, you'll get an error notification. Out of the box, the package can notify you via mail, Slack and Microsoft Teams.
 
 ## Support us
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "require-dev": {
         "laravel/horizon": "^5.9.10",
         "laravel/slack-notification-channel": "^2.4",
+        "laravel-notification-channels/microsoft-teams": "^1.1",
         "nunomaduro/collision": "^5.10|^6.2.1|^6.1",
         "nunomaduro/larastan": "^1.0.3|^2.4",
         "orchestra/testbench": "^6.23|^7.6|^8.0",

--- a/config/health.php
+++ b/config/health.php
@@ -78,6 +78,10 @@ return [
 
             'icon' => null,
         ],
+
+        'microsoft_teams' => [
+            'webhook_url' => env('HEALTH_TEAMS_WEBHOOK_URL', ''),
+        ],
     ],
 
     /*

--- a/config/health.php
+++ b/config/health.php
@@ -28,8 +28,9 @@ return [
     ],
 
     /*
-     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * You can get notified when specific events occur. Out of the box you can use 'mail', 'slack' and 'microsoftTeams.
      * For Slack you need to install laravel/slack-notification-channel.
+     * For Microsoft Teams you need to install laravel-notification-channels/microsoft-teams.
      */
     'notifications' => [
         /*

--- a/docs/configuring-notifications/general.md
+++ b/docs/configuring-notifications/general.md
@@ -9,6 +9,7 @@ Out of the box, the notification can be sent:
 
 - via [mail](/docs/laravel-health/v1/configuring-notifications/via-mail), 
 - via [Slack](/docs/laravel-health/v1/configuring-notifications/via-slack)
+- via [Microsoft Teams](/docs/laravel-health/v1/configuring-notifications/via-microsoft-teams)
 - via [Oh Dear](/docs/laravel-health/v1/configuring-notifications/via-oh-dear) (enables snoozing notifications, and delivery via Telegram, Discord, MS Teams, webhooks, ...)
 
 ## Throttling notifications

--- a/docs/configuring-notifications/via-microsoft-teams.md
+++ b/docs/configuring-notifications/via-microsoft-teams.md
@@ -1,0 +1,32 @@
+---
+title: Via Microsoft Teams
+weight: 2
+---
+
+When a check starts returning warnings or failures, you can get notified via Microsoft Teams.
+
+To use this channel, you must install the Microsoft Teams notification channel.
+
+```bash
+composer require laravel-notification-channels/microsoft-teams
+```
+
+To do this you must set the `CheckFailedNotification` to use the `microsoftTeams` channel. This can be done in the config file.
+
+```php
+// in config/health.php
+
+'notifications' => [
+    Spatie\Health\Notifications\CheckFailedNotification::class => ['microsoftTeams'],
+],
+```
+
+In the `microsoft_teams` key of the `health` config file, you can configure the webhook url for Teams. Set `HEALTH_TEAMS_WEBHOOK_URL` env variable with a valid Microsoft Teams webhook URL. You can learn how to get a webhook URL in the [Microsoft Teams Developer documentation](https://learn.microsoft.com/en-gb/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook).
+
+```php
+// in config/health.php
+
+'microsoft_teams' => [
+    'webhook_url' => env('HEALTH_TEAMS_WEBHOOK_URL', ''),
+],
+```

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -48,8 +48,9 @@ return [
     ],
 
     /*
-     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * You can get notified when specific events occur. Out of the box you can use 'mail', 'slack' and 'microsoftTeams'.
      * For Slack you need to install laravel/slack-notification-channel.
+     * For Microsoft Teams you need to install laravel-notification-channels/microsoft-teams.
      */
     'notifications' => [
         /*

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -20,7 +20,7 @@ Health::checks([
 ]);
 ```
 
-When the used disk space is over 70%, then a notification with a warning will be sent. If it's above 90%, you'll get an error notification. Out of the box, the package can notify you via mail and Slack.
+When the used disk space is over 70%, then a notification with a warning will be sent. If it's above 90%, you'll get an error notification. Out of the box, the package can notify you via mail, Slack and Microsoft Teams.
 
 You'll find a [list of available checks](/docs/laravel-health/v1/available-checks/overview) here. Need a custom check? No problem, you [can create your own check](/docs/laravel-health/v1/basic-usage/creating-custom-checks) in no time.
 

--- a/resources/lang/ar/notifications.php
+++ b/resources/lang/ar/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'التشخيصات التالية أبلغت عن تحذيرات و أخطاء',
 
-    'check_failed_slack_message' => 'بعض التشخيصات في :application_name فشلت',
+    'check_failed_notification_message' => 'بعض التشخيصات في :application_name فشلت',
 
     'health_results' => 'نتائج التشخيص',
 

--- a/resources/lang/bg/notifications.php
+++ b/resources/lang/bg/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Следните проверки съобщават за предупреждения и грешки:',
 
-    'check_failed_slack_message' => 'Някои от проверките на здравето на :application_name са неуспешни.',
+    'check_failed_notification_message' => 'Някои от проверките на здравето на :application_name са неуспешни.',
 
     'health_results' => 'Резултати за проверка на здравето',
 

--- a/resources/lang/bn/notifications.php
+++ b/resources/lang/bn/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'নিম্নলিখিত যাচাইকৃত সতর্কতা এবং ত্রুটি রিপোর্ট করা হয়েছে:',
 
-    'check_failed_slack_message' => ':application_name এর কিছু স্বাস্থ্য পরীক্ষা ব্যর্থ হয়েছে।',
+    'check_failed_notification_message' => ':application_name এর কিছু স্বাস্থ্য পরীক্ষা ব্যর্থ হয়েছে।',
 
     'health_results' => 'স্বাস্থ্য পরীক্ষা ফলাফল',
 

--- a/resources/lang/da/notifications.php
+++ b/resources/lang/da/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Følgende tjeks rapporterede advarsler og fejl:',
 
-    'check_failed_slack_message' => 'Nogle tjeks på :application_name mislykkedes.',
+    'check_failed_notification_message' => 'Nogle tjeks på :application_name mislykkedes.',
 
     'health_results' => 'Health resultater',
 

--- a/resources/lang/de/notifications.php
+++ b/resources/lang/de/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Folgende Kontrollen haben Warnungen und Fehler gemeldet:',
 
-    'check_failed_slack_message' => 'Einige Kontrollen für :application_name sind fehlgeschlagen.',
+    'check_failed_notification_message' => 'Einige Kontrollen für :application_name sind fehlgeschlagen.',
 
     'health_results' => 'Gesundheitsergebnisse',
 

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'The following checks reported warnings and errors:',
 
-    'check_failed_slack_message' => 'Some of the health checks on :application_name have failed.',
+    'check_failed_notification_message' => 'Some of the health checks on :application_name have failed.',
 
     'health_results' => 'Health Results',
 

--- a/resources/lang/es/notifications.php
+++ b/resources/lang/es/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Las siguientes validaciones reportaron warnings y errors:',
 
-    'check_failed_slack_message' => 'Algunos de los chequeos en :application_name han fallado.',
+    'check_failed_notification_message' => 'Algunos de los chequeos en :application_name han fallado.',
 
     'health_results' => 'Resultados del chequeo',
 

--- a/resources/lang/fa/notifications.php
+++ b/resources/lang/fa/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'موارد ذکر شده دارای خطا می باشد:',
 
-    'check_failed_slack_message' => 'بررسی برخی موارد امنیتی در برنامه :application_name از نظر سلامت ناموفق بود',
+    'check_failed_notification_message' => 'بررسی برخی موارد امنیتی در برنامه :application_name از نظر سلامت ناموفق بود',
 
     'health_results' => 'گزارش وضعیت سلامت',
 

--- a/resources/lang/fr/notifications.php
+++ b/resources/lang/fr/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Les tests suivants comportent des avertissements et des erreurs:',
 
-    'check_failed_slack_message' => 'Certains tests de :application_name ont échoué.',
+    'check_failed_notification_message' => 'Certains tests de :application_name ont échoué.',
 
     'health_results' => 'Bilan de santé',
 

--- a/resources/lang/hi/notifications.php
+++ b/resources/lang/hi/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'निम्नलिखित जाँचों ने चेतावनी और त्रुटियों की सूचना दी:',
 
-    'check_failed_slack_message' => ':application_name पर कुछ स्वास्थ्य जाँच विफल हो गई हैं।',
+    'check_failed_notification_message' => ':application_name पर कुछ स्वास्थ्य जाँच विफल हो गई हैं।',
 
     'health_results' => 'स्वास्थ्य जाँच के परिणाम',
 

--- a/resources/lang/it/notifications.php
+++ b/resources/lang/it/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'I seguenti check hanno riportato warning o errori:',
 
-    'check_failed_slack_message' => 'Alcuni check sulla saluta di :application_name sono falliti.',
+    'check_failed_notification_message' => 'Alcuni check sulla saluta di :application_name sono falliti.',
 
     'health_results' => 'Risultati check sulla salute',
 

--- a/resources/lang/nl/notifications.php
+++ b/resources/lang/nl/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'De volgende health checks resulteerden in een warning of error:',
 
-    'check_failed_slack_message' => 'Enkele van de health checks op :application_name faalden.',
+    'check_failed_notification_message' => 'Enkele van de health checks op :application_name faalden.',
 
     'health_results' => 'Health Results',
 

--- a/resources/lang/pt/notifications.php
+++ b/resources/lang/pt/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'As seguintes verificações reportaram avisos e erros:',
 
-    'check_failed_slack_message' => 'Falharam algumas verificações de saúde em :application_name .',
+    'check_failed_notification_message' => 'Falharam algumas verificações de saúde em :application_name .',
 
     'health_results' => 'Resultados da saúde',
 

--- a/resources/lang/ru/notifications.php
+++ b/resources/lang/ru/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Обнаружены следующие ошибки и предупреждения:',
 
-    'check_failed_slack_message' => 'Во время проверки :application_name обнаружены ошибки.',
+    'check_failed_notification_message' => 'Во время проверки :application_name обнаружены ошибки.',
 
     'health_results' => 'Результаты проверки',
 

--- a/resources/lang/sk/notifications.php
+++ b/resources/lang/sk/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Nasledovné kontroly hlásených upozornení a chýb:',
 
-    'check_failed_slack_message' => 'Niektoré kontroly stavu :application_name zlyhali.',
+    'check_failed_notification_message' => 'Niektoré kontroly stavu :application_name zlyhali.',
 
     'health_results' => 'Výsledky',
 

--- a/resources/lang/tr/notifications.php
+++ b/resources/lang/tr/notifications.php
@@ -7,7 +7,7 @@ return [
 
     'check_failed_mail_body' => 'Aşağıda belirtilen sağlik kontrolleri uyari veya hata verdi:',
 
-    'check_failed_slack_message' => ':application_name isimli Uygulamada sağlık kontrolleri başarısız oldu.',
+    'check_failed_notification_message' => ':application_name isimli Uygulamada sağlık kontrolleri başarısız oldu.',
 
     'health_results' => 'Sağlık Durumu Raporu',
 

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -94,6 +94,7 @@ class CheckFailedNotification extends Notification
     {
         $teamsMessage = (new MicrosoftTeamsMessage())
             ->type('error')
+            ->to(config('health.notifications.microsoft_teams.webhook_url'))
             ->content(trans('health::notifications.check_failed_notification_message', $this->transParameters()));
 
         foreach ($this->results as $result) {

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -76,7 +76,7 @@ class CheckFailedNotification extends Notification
             ->error()
             ->from(config('health.notifications.slack.username'), config('health.notifications.slack.icon'))
             ->to(config('health.notifications.slack.channel'))
-            ->content(trans('health::notifications.check_failed_slack_message', $this->transParameters()));
+            ->content(trans('health::notifications.check_failed_notification_message', $this->transParameters()));
 
         foreach ($this->results as $result) {
             $slackMessage->attachment(function (SlackAttachment $attachment) use ($result) {
@@ -94,7 +94,7 @@ class CheckFailedNotification extends Notification
     {
         $teamsMessage = (new MicrosoftTeamsMessage())
             ->type('error')
-            ->content(trans('health::notifications.check_failed_slack_message', $this->transParameters()));
+            ->content(trans('health::notifications.check_failed_notification_message', $this->transParameters()));
 
         foreach ($this->results as $result) {
             $teamsMessage->addStartGroupToSection();

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 use Spatie\Health\Checks\Result;
 use Spatie\Health\Enums\Status;
 

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -98,7 +98,6 @@ class CheckFailedNotification extends Notification
             ->content(trans('health::notifications.check_failed_notification_message', $this->transParameters()));
 
         foreach ($this->results as $result) {
-            $teamsMessage->addStartGroupToSection();
             $teamsMessage->fact($result->check->getLabel(), $result->getNotificationMessage());
         }
 

--- a/src/Notifications/CheckFailedNotification.php
+++ b/src/Notifications/CheckFailedNotification.php
@@ -90,6 +90,20 @@ class CheckFailedNotification extends Notification
         return $slackMessage;
     }
 
+    public function toMicrosoftTeams(): MicrosoftTeamsMessage
+    {
+        $teamsMessage = (new MicrosoftTeamsMessage())
+            ->type('error')
+            ->content(trans('health::notifications.check_failed_slack_message', $this->transParameters()));
+
+        foreach ($this->results as $result) {
+            $teamsMessage->addStartGroupToSection();
+            $teamsMessage->fact($result->check->getLabel(), $result->getNotificationMessage());
+        }
+
+        return $teamsMessage;
+    }
+
     /**
      * @return array<string, string>
      */

--- a/src/Notifications/Notifiable.php
+++ b/src/Notifications/Notifiable.php
@@ -19,6 +19,11 @@ class Notifiable
         return config('health.notifications.slack.webhook_url');
     }
 
+    public function routeNotificationForMicrosoftTeams(): string
+    {
+        return config('health.notifications.microsoft_teams.webhook_url');
+    }
+
     public function getKey(): int
     {
         return 1;


### PR DESCRIPTION
- Add the ability to send health notifications to a Microsoft Teams webhook using [Microsoft Teams Notification Channel](https://github.com/laravel-notification-channels/microsoft-teams)
- Rename `health::notifications.check_failed_slack_message` to `health::notifications.check_failed_notification_message` in order to reuse it for both Slack and Teams
- Add documentation for this feature