### PR TITLE
Allow declaring custom or multiple notification classes in health.php

### DIFF
--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -12,7 +12,6 @@ use Spatie\Health\Events\CheckEndedEvent;
 use Spatie\Health\Events\CheckStartingEvent;
 use Spatie\Health\Exceptions\CheckDidNotComplete;
 use Spatie\Health\Health;
-use Spatie\Health\Notifications\CheckFailedNotification;
 use Spatie\Health\ResultStores\ResultStore;
 
 class RunHealthChecksCommand extends Command
@@ -110,11 +109,13 @@ class RunHealthChecksCommand extends Command
         /** @var array<int, Result> $results */
         $results = $resultsWithMessages->toArray();
 
-        $failedNotificationClass = $this->getFailedNotificationClass();
+        $failedNotificationClasses = $this->getFailedNotificationClasses();
 
-        $notification = (new $failedNotificationClass($results));
+        foreach ($failedNotificationClasses as $failedNotificationClass) {
+            $notification = (new $failedNotificationClass($results));
 
-        $notifiable->notify($notification);
+            $notifiable->notify($notification);
+        }
 
         return $this;
     }
@@ -162,10 +163,10 @@ class RunHealthChecksCommand extends Command
     }
 
     /**
-     * @return class-string<CheckFailedNotification>
+     * @return array<class-string>
      */
-    protected function getFailedNotificationClass(): string
+    protected function getFailedNotificationClasses(): array
     {
-        return CheckFailedNotification::class;
+        return array_keys(config('health.notifications.notifications'));
     }
 }


### PR DESCRIPTION
BUG: When trying to create a custom notification for laravel-health I found out that RunHealthChecksCommand `getFailedNotificationClass()` returns a hardcoded `Spatie\Health\Notifications\CheckFailedNotification::class` which makes it impossible to override.

- Rename `getFailedNotificationClass()` to `getFailedNotificationClasses()` and make it read the an array with the keys (class names) from `config('health.notifications.notifications')`
- Modify `sendNotification()` method so that it loops through the provided classes, instantiates them and sends notifications.

This change should not have any effect in existing installations but would allow users to use their own notification or even trigger multiple notifications if they declare them inside health.php:

`
'notifications' => [
    Spatie\Health\Notifications\CheckFailedNotification::class => ['mail'],
    App\Notifications\CustomCheckFailedNotification::class => ['teams','signal','irc'],
],
`
