### PR TITLE
Mysql Connections Count is not accurate Fixes #198

### DIFF
--- a/src/Support/DbConnectionInfo.php
+++ b/src/Support/DbConnectionInfo.php
@@ -12,7 +12,7 @@ class DbConnectionInfo
     public function connectionCount(ConnectionInterface $connection): int
     {
         return match (true) {
-            $connection instanceof MySqlConnection => (int) $connection->selectOne('show status where variable_name = "threads_connected"')->Value,
+            $connection instanceof MySqlConnection => (int) $connection->selectOne('SELECT COUNT(*) FROM information_schema.PROCESSLIST')->{"COUNT(*)"},
             $connection instanceof PostgresConnection => (int) $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections,
             default => throw DatabaseNotSupported::make($connection),
         };


### PR DESCRIPTION
Per Discussion https://github.com/spatie/laravel-health/discussions/198


> as you can see here:
> 
> https://github.com/spatie/laravel-health/blob/1dee638806b6b2d8971363bf1e26cb17835e2dcb/src/Support/DbConnectionInfo.php#L15
> 
> we're using `show status where variable_name = "threads_connected"` which shows overall server processes not my user-only this is wrong when running several apps on the same server and setting `max_user_connections` to like 60 per app. it should warn me when my user exceeds the limit not the overall server.
> 
> so it should be changed to `SELECT COUNT(*) FROM information_schema.PROCESSLIST;`
> 
> this won't be breaking change for others, as if you're the only user on the server or using root mysql, this will return same data, but if user is shared with other apps or other users (ex: Shared Hosting) it will return his processes only, so he can be notified when his app is doing something wrong.
> 
> tell me what you think and i can open PR.


If interested in this PR and wants to use it.

open composer.json and add the following:
in `require`
```json
        "spatie/laravel-health": "dev-fix/mysql-count-per-user as 1.23.4"
```

in `repositories`
```json
        {
            "type": "vcs",
            "url": "https://github.com/Saifallak/laravel-health.git"
        }
```
