### PR TITLE
Fix getting default queue settings

### DIFF
--- a/src/Checks/Checks/QueueCheck.php
+++ b/src/Checks/Checks/QueueCheck.php
@@ -57,7 +57,7 @@ class QueueCheck extends Check
 
     public function getQueues(): array
     {
-        return $this->onQueues ?? [$this->getDefaultQueue(config('queue.driver'))];
+        return $this->onQueues ?? [$this->getDefaultQueue(config('queue.default'))];
     }
 
     protected function getDefaultQueue($connection)

--- a/tests/Checks/QueueCheckTest.php
+++ b/tests/Checks/QueueCheckTest.php
@@ -97,3 +97,15 @@ it('can specify on which queues check should be performed', function () {
     Queue::assertPushedOn('email', HealthQueueJob::class);
     Queue::assertPushedOn('payment', HealthQueueJob::class);
 });
+
+it('can get default queue settings', function () {
+    // Set default queue connection
+    $queueConnection = uniqid('connection');
+    config()->set('queue.default', $queueConnection);
+
+    // Set default queue name
+    $queueName = uniqid('queue');
+    config()->set("queue.connections.{$queueConnection}.queue", $queueName);
+
+    expect($this->queueCheck->getQueues())->toBe([$queueName]);
+});


### PR DESCRIPTION
This is follow-up for #197 

**Problem description**
Queue check doesn't work properly when you name your queue other than `default`.

**Problem details**
The issue is that in laravel the [default queue connection is stored as](https://github.com/laravel/laravel/blob/10.x/config/queue.php#L16) `config('queue.default')`, but this package calls `config('queue. driver')`. As a result, the package cannot find the connection config and selects `default` queue as one to check:
```
protected function getDefaultQueue($connection)
{
    return config("queue.connections.{$connection}.queue", 'default');
}
```