### PR TITLE
Fixed the CacheCheck causing race conditions in some cases

### DIFF
--- a/src/Checks/Checks/CacheCheck.php
+++ b/src/Checks/Checks/CacheCheck.php
@@ -45,7 +45,7 @@ class CacheCheck extends Check
     {
         $expectedValue = Str::random(5);
 
-        $cacheName = "health:check-{$expectedValue}";
+        $cacheName = "laravel-health:check-{$expectedValue}";
 
         Cache::driver($driver)->put($cacheName, $expectedValue, 10);
 

--- a/src/Checks/Checks/CacheCheck.php
+++ b/src/Checks/Checks/CacheCheck.php
@@ -45,9 +45,13 @@ class CacheCheck extends Check
     {
         $expectedValue = Str::random(5);
 
-        Cache::driver($driver)->put('laravel-health:check', $expectedValue, 10);
+        $cacheName = "health:check-{$expectedValue}";
 
-        $actualValue = Cache::driver($driver)->get('laravel-health:check');
+        Cache::driver($driver)->put($cacheName, $expectedValue, 10);
+
+        $actualValue = Cache::driver($driver)->get($cacheName);
+
+        Cache::driver($driver)->forget($cacheName);
 
         return $actualValue === $expectedValue;
     }


### PR DESCRIPTION
If you have multiple environments, like subdeployments, and you run the `CacheCheck`, it can cause race conditions, because multiple environments write / read the same cache key (`laravel-health:check`).

By adding the random string from the test cache value to the key itself, we can avoid that race condition.

Also added `Cache->forget()`, so we don't flood the cache with all those randomized keys.