### PR TITLE
Fix: updated migration to drop table on rollback

### DIFF
--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -10,7 +10,7 @@ return new class extends Migration
     public function up()
     {
         $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
-    
+
         Schema::create($tableName, function (Blueprint $table) {
             $table->id();
 
@@ -25,10 +25,15 @@ return new class extends Migration
 
             $table->timestamps();
         });
-        
+
         Schema::table($tableName, function(Blueprint $table) {
             $table->index('created_at');
             $table->index('batch');
         });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(EloquentHealthResultStore::getHistoryItemInstance()->getTable());
     }
 };


### PR DESCRIPTION
Added migration `down` method to drop the table on `migration:rollback` command. 