### PR TITLE
Update nunomaduro/termwind to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/database": "^8.75|^9.0|^10.0",
         "illuminate/notifications": "^8.75|^9.0|^10.0",
         "illuminate/support": "^8.75|^9.0|^10.0",
-        "nunomaduro/termwind": "^2.0.0",
+        "nunomaduro/termwind": "^1.0|^2.0",
         "spatie/enum": "^3.13",
         "spatie/laravel-package-tools": "^1.12.1",
         "spatie/regex": "^3.1.1|^3.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/database": "^8.75|^9.0|^10.0",
         "illuminate/notifications": "^8.75|^9.0|^10.0",
         "illuminate/support": "^8.75|^9.0|^10.0",
-        "nunomaduro/termwind": "^1.14",
+        "nunomaduro/termwind": "^2.0.0",
         "spatie/enum": "^3.13",
         "spatie/laravel-package-tools": "^1.12.1",
         "spatie/regex": "^3.1.1|^3.1",


### PR DESCRIPTION
I'm trying to upgrade `nunomaduro/collision` to 8.x in my project. This fails because it depends on `nunomaduro/termwind` 2.0 and `spatie/laravel-health` depends on 1.14. 

![Scherm­afbeelding 2024-01-19 om 22 58 40](https://github.com/spatie/laravel-health/assets/4047804/94ba0664-50b2-49d3-acc0-e0b5e857f20b)

Termwind drops support for Symfony 5 and 6 and it seems like it drops support for PHP 8.1 as well. I guess that means this package needs to drop support for 8.0 and 8.1 as well?

