### PR TITLE
Added Different Database Connection Support

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -2,20 +2,13 @@
 
 return [
     /*
-     * Configure your database connection if you want to use a different
-     * database to store the values.
-     */
-    'database' => [
-        'connection' => env('HEALTH_DATABASE_CONNECTION', env('DB_CONNECTION')),
-    ],
-
-    /*
      * A result store is responsible for saving the results of the checks. The
      * `EloquentHealthResultStore` will save results in the database. You
      * can use multiple stores at the same time.
      */
     'result_stores' => [
         Spatie\Health\ResultStores\EloquentHealthResultStore::class => [
+            'connection' => env('HEALTH_DATABASE_CONNECTION', env('DB_CONNECTION')),
             'model' => Spatie\Health\Models\HealthCheckResultHistoryItem::class,
             'keep_history_for_days' => 5,
         ],

--- a/config/health.php
+++ b/config/health.php
@@ -1,6 +1,13 @@
 <?php
 
 return [
+    /*
+     * Configure your database connection if you want to use a different
+     * database to store the values.
+     */
+    'database' => [
+        'connection' => env('HEALTH_DATABASE_CONNECTION', env('DB_CONNECTION')),
+    ],
 
     /*
      * A result store is responsible for saving the results of the checks. The

--- a/config/health.php
+++ b/config/health.php
@@ -8,7 +8,7 @@ return [
      */
     'result_stores' => [
         Spatie\Health\ResultStores\EloquentHealthResultStore::class => [
-            'connection' => env('HEALTH_DATABASE_CONNECTION', env('DB_CONNECTION')),
+            'connection' => env('HEALTH_DB_CONNECTION', env('DB_CONNECTION')),
             'model' => Spatie\Health\Models\HealthCheckResultHistoryItem::class,
             'keep_history_for_days' => 5,
         ],

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -9,9 +9,10 @@ return new class extends Migration
 {
     public function up()
     {
+        $connection = config('health.database.connection');
         $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
     
-        Schema::create($tableName, function (Blueprint $table) {
+        Schema::connection($connection)->create($tableName, function (Blueprint $table) {
             $table->id();
 
             $table->string('check_name');
@@ -26,7 +27,7 @@ return new class extends Migration
             $table->timestamps();
         });
         
-        Schema::table($tableName, function(Blueprint $table) {
+        Schema::connection($connection)->table($tableName, function(Blueprint $table) {
             $table->index('created_at');
             $table->index('batch');
         });

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -3,13 +3,14 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Spatie\Health\Models\HealthCheckResultHistoryItem;
 use Spatie\Health\ResultStores\EloquentHealthResultStore;
 
 return new class extends Migration
 {
     public function up()
     {
-        $connection = config('health.result_stores.'.EloquentHealthResultStore::class.'.connection');
+        $connection = (new HealthCheckResultHistoryItem())->getConnectionName();
         $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
     
         Schema::connection($connection)->create($tableName, function (Blueprint $table) {

--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration
 {
     public function up()
     {
-        $connection = config('health.database.connection');
+        $connection = config('health.result_stores.'.EloquentHealthResultStore::class.'.connection');
         $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
     
         Schema::connection($connection)->create($tableName, function (Blueprint $table) {

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -32,6 +32,11 @@ class HealthCheckResultHistoryItem extends Model
         'started_failing_at' => 'timestamp',
     ];
 
+    public function getConnectionName(): string
+    {
+        return config('health.database.connection');
+    }
+
     public function prunable(): Builder
     {
         $days = config('health.result_stores.'.EloquentHealthResultStore::class.'.keep_history_for_days') ?? 5;

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -34,7 +34,7 @@ class HealthCheckResultHistoryItem extends Model
 
     public function getConnectionName(): string
     {
-        return config('health.database.connection');
+        return config('health.result_stores.'.EloquentHealthResultStore::class.'.connection');
     }
 
     public function prunable(): Builder

--- a/src/Models/HealthCheckResultHistoryItem.php
+++ b/src/Models/HealthCheckResultHistoryItem.php
@@ -34,7 +34,8 @@ class HealthCheckResultHistoryItem extends Model
 
     public function getConnectionName(): string
     {
-        return config('health.result_stores.'.EloquentHealthResultStore::class.'.connection');
+        return config('health.result_stores.'.EloquentHealthResultStore::class.'.connection')
+            ?: config('database.default');
     }
 
     public function prunable(): Builder


### PR DESCRIPTION
Hi! This PR introduce the capability for the EloquentHealthResultStore to support a different database connection to store the data. 

The primary motivation behind this enhancement is to enable applications to maintain a clean and focused main database by offloading monitoring logs to a separate database. In many applications, especially those with high traffic or complex data structures, the main database is optimized for performance and critical operations. Monitoring logs, while essential for maintaining the health and performance of the application, can quickly grow in size and potentially clutter the main database. This can lead to decreased performance and complicate database maintenance tasks.

Regards!