### PR TITLE
Added the option to specify a HTTP Authentication token for the Meilisearch check

### DIFF
--- a/docs/available-checks/meilisearch.md
+++ b/docs/available-checks/meilisearch.md
@@ -47,3 +47,16 @@ Health::checks([
     MeiliSearchCheck::new()->timeout(2),
 ]);
 ```
+
+### Adding an authorization header
+
+You can use `token()` to add an authorization header to the request.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\MeiliSearchCheck;
+
+Health::checks([
+    MeiliSearchCheck::new()->token('auth-token'),
+]);
+```

--- a/src/Checks/Checks/MeiliSearchCheck.php
+++ b/src/Checks/Checks/MeiliSearchCheck.php
@@ -13,6 +13,7 @@ class MeiliSearchCheck extends Check
     protected int $timeout = 1;
 
     protected string $url = 'http://127.0.0.1:7700/health';
+    protected ?string $token = null;
 
     public function timeout(int $seconds): self
     {
@@ -28,6 +29,13 @@ class MeiliSearchCheck extends Check
         return $this;
     }
 
+    public function token(string $token): self
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
     public function getLabel(): string
     {
         return $this->getName();
@@ -36,7 +44,10 @@ class MeiliSearchCheck extends Check
     public function run(): Result
     {
         try {
-            $response = Http::timeout($this->timeout)->asJson()->get($this->url);
+            $response = Http::timeout($this->timeout)
+                ->when($this->token !== null, fn ($r) => $r->withToken($this->token))
+                ->asJson()
+                ->get($this->url);
         } catch (Exception) {
             return Result::make()
                 ->failed()


### PR DESCRIPTION
Most Meilisearch instances are protected with a token (e.g. when you use the cloud version).

There was no way to specify the token for the check, so I’ve added an option to specify it.