### PR TITLE
Prevent pending HealthQeueueJob in Horizon

### DIFF
--- a/src/Jobs/HealthQueueJob.php
+++ b/src/Jobs/HealthQueueJob.php
@@ -28,5 +28,8 @@ class HealthQueueJob implements ShouldQueue
                 $this->queueCheck->getCacheKey($this->queue),
                 now()->timestamp,
             );
+
+        # https://github.com/laravel/horizon/issues/1034
+        sleep(2);
     }
 }


### PR DESCRIPTION
Hi there,

I noticed on my production server that there were a lot of `HealthQueueJob` entries in the "Pending Jobs" list on Horizon.

After some searching online, I found [this issue](https://github.com/laravel/horizon/issues/1034) on GitHub. They suggested that you can add a sleep to prevent this from happening. As written in the docs, this job needs to run every minute, so adding a pauze of 2 seconds could be the solution in this case?

The jobs runs on average 0.005 seconds on the server, which is **too** fast from what I read online...

Maybe 1 second will also be enough, but I don't know for sure.

👋  Edwin