### PR TITLE
Add running status to MeiliSearchCheck

### DIFF
--- a/src/Checks/Checks/MeiliSearchCheck.php
+++ b/src/Checks/Checks/MeiliSearchCheck.php
@@ -73,7 +73,7 @@ class MeiliSearchCheck extends Check
 
         $status = Arr::get($response, 'status');
 
-        if ($status !== 'available') {
+        if (! in_array($status, ['available', 'running'])) {
             return Result::make()
                 ->failed()
                 ->shortSummary(ucfirst($status))


### PR DESCRIPTION
https://github.com/meilisearch/meilisearch/blob/b1844b0c270e6819e1e52a0eaa40cc1c3d9a45fb/meilisearch/src/routes/mod.rs#L282

It seems they changed the response message. This should add `running` as OK-status, but also keep the previous one, just to be backwards compatible.