### PR TITLE
Update installation-setup.md to move schedule command to route/console

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -156,12 +156,11 @@ These steps are not necessary when using the `JsonFileResultStore`.
 If you want to let your application send notifications when something is wrong, you should schedule the `RunHealthChecksCommand` to run every minute.
 
 ```php
-// in app/Console/Kernel.php
+// in route/console.php
+use Illuminate\Support\Facades\Schedule;
 
-protected function schedule(Schedule $schedule)
-{
-    $schedule->command(\Spatie\Health\Commands\RunHealthChecksCommand::class)->everyMinute();
-}
+    Schedule::->command(\Spatie\Health\Commands\RunHealthChecksCommand::class)->everyMinute();
+
 ```
 
 ## Running the checks by sending HTTP requests

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -159,8 +159,7 @@ If you want to let your application send notifications when something is wrong, 
 // in route/console.php
 use Illuminate\Support\Facades\Schedule;
 
-    Schedule::->command(\Spatie\Health\Commands\RunHealthChecksCommand::class)->everyMinute();
-
+Schedule::command(\Spatie\Health\Commands\RunHealthChecksCommand::class)->everyMinute();
 ```
 
 ## Running the checks by sending HTTP requests


### PR DESCRIPTION
Laravel 11 has no Kernel file in the app anymore, the Schedule for should be set in the routes/console.php