### PR TITLE
Add summaray for detailed check

### DIFF
--- a/src/ResultStores/StoredCheckResults/StoredCheckResults.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResults.php
@@ -81,10 +81,19 @@ class StoredCheckResults
         );
     }
 
+    public function getFailing()
+    {
+        return $this->storedCheckResults->filter(
+            fn (StoredCheckResult $line) => $line->status !== Status::ok()->value
+        );
+    }
+
     public function toJson(): string
     {
         return (string) json_encode([
             'finishedAt' => $this->finishedAt->getTimestamp(),
+            'status' => $this->allChecksOk() ? 'ok' : 'failing',
+            'failingChecks' => $this->getFailing()->map->name->implode(', ') ?: '',
             'checkResults' => $this->storedCheckResults->map(fn (StoredCheckResult $line) => $line->toArray()),
         ]);
     }

--- a/src/ResultStores/StoredCheckResults/StoredCheckResults.php
+++ b/src/ResultStores/StoredCheckResults/StoredCheckResults.php
@@ -93,7 +93,7 @@ class StoredCheckResults
         return (string) json_encode([
             'finishedAt' => $this->finishedAt->getTimestamp(),
             'status' => $this->allChecksOk() ? 'ok' : 'failing',
-            'failingChecks' => $this->getFailing()->map->name->implode(', ') ?: '',
+            'failingChecks' => $this->getFailing()->map->name ?: [],
             'checkResults' => $this->storedCheckResults->map(fn (StoredCheckResult $line) => $line->toArray()),
         ]);
     }

--- a/tests/ResultStores/StoredCheckResultsTest.php
+++ b/tests/ResultStores/StoredCheckResultsTest.php
@@ -28,6 +28,17 @@ it('has a method to check if one or more checks are failing', function () {
     expect($storedCheckResults->containsFailingCheck())->toBeTrue();
 });
 
+it('returns a list of failed checks', function () {
+    $storedCheckResults = new StoredCheckResults(new DateTime(), collect([
+        makeStoredCheckResultWithStatus(Status::warning()),
+        makeStoredCheckResultWithStatus(Status::ok()),
+    ]));
+    $failing = $storedCheckResults->getFailing();
+    expect($failing->first()->status)->toBe('warning');
+    expect($failing->first()->name)->toBe('test');
+    expect($failing->count())->toBe(1);
+});
+
 it('has a method to check if all checks are good', function () {
     $storedCheckResults = new StoredCheckResults(new DateTime(), collect([
         makeStoredCheckResultWithStatus(Status::ok()),

--- a/tests/__snapshots__/CacheHealthResultStoreTest__it_can_cache_check_results__1.json
+++ b/tests/__snapshots__/CacheHealthResultStoreTest__it_can_cache_check_results__1.json
@@ -1,7 +1,7 @@
 {
     "finishedAt": 1609459200,
     "status": "ok",
-    "failingChecks": "",
+    "failingChecks": [],
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/CacheHealthResultStoreTest__it_can_cache_check_results__1.json
+++ b/tests/__snapshots__/CacheHealthResultStoreTest__it_can_cache_check_results__1.json
@@ -1,5 +1,7 @@
 {
     "finishedAt": 1609459200,
+    "status": "ok",
+    "failingChecks": "",
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/CacheHealthResultStoreTest__it_can_retrieve_the_latest_results_from_cache__1.json
+++ b/tests/__snapshots__/CacheHealthResultStoreTest__it_can_retrieve_the_latest_results_from_cache__1.json
@@ -1,7 +1,7 @@
 {
     "finishedAt": 1609459200,
     "status": "ok",
-    "failingChecks": "",
+    "failingChecks": [],
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/CacheHealthResultStoreTest__it_can_retrieve_the_latest_results_from_cache__1.json
+++ b/tests/__snapshots__/CacheHealthResultStoreTest__it_can_retrieve_the_latest_results_from_cache__1.json
@@ -1,5 +1,7 @@
 {
     "finishedAt": 1609459200,
+    "status": "ok",
+    "failingChecks": "",
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/EloquentHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
+++ b/tests/__snapshots__/EloquentHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
@@ -1,7 +1,7 @@
 {
     "finishedAt": 1609459200,
     "status": "ok",
-    "failingChecks": "",
+    "failingChecks": [],
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/EloquentHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
+++ b/tests/__snapshots__/EloquentHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
@@ -1,5 +1,7 @@
 {
     "finishedAt": 1609459200,
+    "status": "ok",
+    "failingChecks": "",
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_display_the_results_as_json_when_the_request_accepts_json__1.yml
+++ b/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_display_the_results_as_json_when_the_request_accepts_json__1.yml
@@ -1,3 +1,5 @@
 finishedAt: 1609459200
+status: failing
+failingChecks: FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_display_the_results_as_json_when_the_request_accepts_json__1.yml
+++ b/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_display_the_results_as_json_when_the_request_accepts_json__1.yml
@@ -1,5 +1,6 @@
 finishedAt: 1609459200
 status: failing
-failingChecks: FakeUsedDiskSpace
+failingChecks:
+    - FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_return_the_configured_status_for_a_unhealthy_check__1.yml
+++ b/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_return_the_configured_status_for_a_unhealthy_check__1.yml
@@ -1,3 +1,5 @@
 finishedAt: 1609459200
+status: failing
+failingChecks: FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_return_the_configured_status_for_a_unhealthy_check__1.yml
+++ b/tests/__snapshots__/HealthCheckJsonResultsControllerTest__it_will_return_the_configured_status_for_a_unhealthy_check__1.yml
@@ -1,5 +1,6 @@
 finishedAt: 1609459200
 status: failing
-failingChecks: FakeUsedDiskSpace
+failingChecks:
+    - FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
+++ b/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
@@ -1,7 +1,7 @@
 {
     "finishedAt": 1609459200,
     "status": "ok",
-    "failingChecks": "",
+    "failingChecks": [],
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
+++ b/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_retrieve_the_latest_results_from_json__1.json
@@ -1,5 +1,7 @@
 {
     "finishedAt": 1609459200,
+    "status": "ok",
+    "failingChecks": "",
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_write_check_results_to_a_json_file__1.json
+++ b/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_write_check_results_to_a_json_file__1.json
@@ -1,7 +1,7 @@
 {
     "finishedAt": 1609459200,
     "status": "ok",
-    "failingChecks": "",
+    "failingChecks": [],
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_write_check_results_to_a_json_file__1.json
+++ b/tests/__snapshots__/JsonFileHealthResultStoreTest__it_can_write_check_results_to_a_json_file__1.json
@@ -1,5 +1,7 @@
 {
     "finishedAt": 1609459200,
+    "status": "ok",
+    "failingChecks": "",
     "checkResults": [
         {
             "name": "FakeUsedDiskSpace",

--- a/tests/__snapshots__/OhDearCheckResultsTest__it_will_display_the_results_as_json_when_the_endpoint_is_enabled_and_the_secret_is_correct__1.yml
+++ b/tests/__snapshots__/OhDearCheckResultsTest__it_will_display_the_results_as_json_when_the_endpoint_is_enabled_and_the_secret_is_correct__1.yml
@@ -1,3 +1,5 @@
 finishedAt: 1609459200
+status: failing
+failingChecks: FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/OhDearCheckResultsTest__it_will_display_the_results_as_json_when_the_endpoint_is_enabled_and_the_secret_is_correct__1.yml
+++ b/tests/__snapshots__/OhDearCheckResultsTest__it_will_display_the_results_as_json_when_the_endpoint_is_enabled_and_the_secret_is_correct__1.yml
@@ -1,5 +1,6 @@
 finishedAt: 1609459200
 status: failing
-failingChecks: FakeUsedDiskSpace
+failingChecks:
+    - FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/OhDearCheckResultsTest__it_will_run_the_checks_when_visiting_the_endpoint_if_the_relevant_config_option_is_set_to_true__1.yml
+++ b/tests/__snapshots__/OhDearCheckResultsTest__it_will_run_the_checks_when_visiting_the_endpoint_if_the_relevant_config_option_is_set_to_true__1.yml
@@ -1,3 +1,5 @@
 finishedAt: 1609459200
+status: failing
+failingChecks: FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/OhDearCheckResultsTest__it_will_run_the_checks_when_visiting_the_endpoint_if_the_relevant_config_option_is_set_to_true__1.yml
+++ b/tests/__snapshots__/OhDearCheckResultsTest__it_will_run_the_checks_when_visiting_the_endpoint_if_the_relevant_config_option_is_set_to_true__1.yml
@@ -1,5 +1,6 @@
 finishedAt: 1609459200
 status: failing
-failingChecks: FakeUsedDiskSpace
+failingChecks:
+    - FakeUsedDiskSpace
 checkResults:
     - { name: FakeUsedDiskSpace, label: 'Fake Used Disk Space', notificationMessage: 'The disk is almost full (100% used).', shortSummary: 100%, status: failed, meta: { disk_space_used_percentage: 100 } }

--- a/tests/__snapshots__/ReportTest__it_can_create_create_report__1.txt
+++ b/tests/__snapshots__/ReportTest__it_can_create_create_report__1.txt
@@ -1,1 +1,1 @@
-{"finishedAt":978307200,"checkResults":[{"name":"name","label":"label","notificationMessage":"message","shortSummary":"summary","status":"ok","meta":{"name":"value"}}]}
+{"finishedAt":978307200,"status":"ok","failingChecks":"","checkResults":[{"name":"name","label":"label","notificationMessage":"message","shortSummary":"summary","status":"ok","meta":{"name":"value"}}]}

--- a/tests/__snapshots__/ReportTest__it_can_create_create_report__1.txt
+++ b/tests/__snapshots__/ReportTest__it_can_create_create_report__1.txt
@@ -1,1 +1,1 @@
-{"finishedAt":978307200,"status":"ok","failingChecks":"","checkResults":[{"name":"name","label":"label","notificationMessage":"message","shortSummary":"summary","status":"ok","meta":{"name":"value"}}]}
+{"finishedAt":978307200,"status":"ok","failingChecks":[],"checkResults":[{"name":"name","label":"label","notificationMessage":"message","shortSummary":"summary","status":"ok","meta":{"name":"value"}}]}


### PR DESCRIPTION
This the same as #235
I moved the changes to another branch in my fork. I thought I would be able to change the fork branch in the PR, but that was not possible. So here is another identical PR. Sorry about that.

Description from #235:

> I thought it would be very useful to have a summary to be able to quickly check the status of the detailed JSON endpoint when we built our dashboard. Then we don't have to loop though the results if everything is fine, and just check the details if needed.
