### PR TITLE
Add support for checking backups on filesystem disks

### DIFF
--- a/src/Support/BackupFile.php
+++ b/src/Support/BackupFile.php
@@ -1,0 +1,34 @@
+<?php
+namespace Spatie\Health\Support;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
+
+class BackupFile {
+    protected ?SymfonyFile $file = null;
+
+    public function __construct(
+        protected string $path,
+        protected ?Filesystem $disk = null,
+    ) {
+        if (!$disk) {
+            $this->file = new SymfonyFile($path);
+        }
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    public function size(): int
+    {
+        return $this->file ? $this->file->getSize() : $this->disk->size($this->path);
+    }
+
+    public function lastModified(): int
+    {
+        return $this->file ? $this->file->getMTime() : $this->disk->lastModified($this->path);
+    }
+
+}

--- a/tests/Checks/BackupsCheckTest.php
+++ b/tests/Checks/BackupsCheckTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Storage;
 use Spatie\Health\Checks\Checks\BackupsCheck;
 use Spatie\Health\Enums\Status;
 use Spatie\Health\Facades\Health;
@@ -147,6 +148,76 @@ it('can make sure that there are not too much backups', function () {
     $result = $this->backupsCheck
         ->locatedAt($this->temporaryDirectory->path('*.zip'))
         ->numberOfBackups(max: 2)
+        ->run();
+    expect($result)->status->toBe(Status::failed());
+});
+
+it('will pass if the backup is at least than the given size when loaded from filesystem disk', function (int $sizeInMb) {
+
+    Storage::fake('backups');
+
+    $tempFile = $this->temporaryDirectory->path('hey.zip');
+
+    shell_exec("truncate -s {$sizeInMb}M {$tempFile}");
+
+    Storage::disk('backups')->put('backups/hey.zip',file_get_contents($tempFile) );
+
+    $result = $this->backupsCheck
+        ->onDisk('backups')
+        ->locatedAt('backups')
+        ->atLeastSizeInMb(5)
+        ->run();
+
+    expect($result)->status->toBe(Status::ok());
+})->with([
+    [5],
+    [6],
+]);
+
+it('can check if the youngest backup is recent enough when loaded from filesystem disk', function () {
+
+    Storage::fake('backups');
+    Storage::disk('backups')->put('backups/hey.zip', 'content');
+
+    testTime()->addMinutes(4);
+
+    $result = $this->backupsCheck
+        ->onDisk('backups')
+        ->locatedAt('backups')
+        ->youngestBackShouldHaveBeenMadeBefore(now()->subMinutes(5)->startOfMinute())
+        ->run();
+
+    expect($result)->status->toBe(Status::ok());
+
+    testTime()->addMinutes(2);
+
+    $result = $this->backupsCheck
+        ->locatedAt($this->temporaryDirectory->path('*.zip'))
+        ->youngestBackShouldHaveBeenMadeBefore(now()->subMinutes(5))
+        ->run();
+    expect($result)->status->toBe(Status::failed());
+});
+
+it('can check if the oldest backup is old enough when loaded from filesystem disk', function () {
+
+    Storage::fake('backups');
+    Storage::disk('backups')->put('backups/hey.zip', 'content');
+
+    testTime()->addMinutes(4);
+
+    $result = $this->backupsCheck
+        ->onDisk('backups')
+        ->locatedAt('backups')
+        ->oldestBackShouldHaveBeenMadeAfter(now()->subMinutes(5))
+        ->run();
+
+    expect($result)->status->toBe(Status::failed());
+
+    testTime()->addMinutes(2);
+
+    $result = $this->backupsCheck
+        ->locatedAt($this->temporaryDirectory->path('*.zip'))
+        ->oldestBackShouldHaveBeenMadeAfter(now()->subMinutes(5))
         ->run();
     expect($result)->status->toBe(Status::failed());
 });


### PR DESCRIPTION
This adds support for checking backups on any filesystem you have defined in your Laravel installation. Including for example an S3 bucket. 

The syntax is very simple. Something like this works with [spatie/laravel-backup](https://github.com/spatie/laravel-backup) when backups are saved to S3:
```
            BackupsCheck::new()
                        ->onDisk('backups_remote')
                        ->locatedAt(config('backup.backup.name'))
```

I needed to create a new file `BackupFile.php` to abstract away the filesystem from `SymfonyFile` that you used before. This was the best solution to make this backwards compatible and support the glob style syntax in `->locatedAt()`. When using Filesystem disk glob is not available and therefore that is not supported when using a Laravel disk. 

In the next major version I would suggest to stop using `SymfonyFile` and only use the Laravel FIlesystem. I think that is probably the right way to do this. With the filter option below, we can restore all current functionality. 

Questions:
1) Should we look for files recursively in the folder passed in with `locatedAt`?
2) As this removes the glob supper, do we need to let the user filter the files? For example with a callback? I don't need that in my use case, but I can see that others would need that. For example:  `->filterFilesUsing(fn ($path) => preg_match('/backup\/[0-9-]+\.zip/', $path)`. I can add that if you think it is a good idea. 

I can also update the docs if you want.