### PR TITLE
Add down method for migration

### DIFF
--- a/database/migrations/create_health_tables.php.stub
+++ b/database/migrations/create_health_tables.php.stub
@@ -33,4 +33,15 @@ return new class extends Migration
             $table->index('batch');
         });
     }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $connection = (new HealthCheckResultHistoryItem())->getConnectionName();
+        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
+
+        Schema::connection($connection)->dropIfExists($tableName);
+    }
 };


### PR DESCRIPTION
This PR introduces the `down` method for the existing migrations.
The `down` method is essential for rolling back database changes when performing a migration rollback.