### PR TITLE
Performance optimizations for backups check

### DIFF
--- a/docs/available-checks/backups.md
+++ b/docs/available-checks/backups.md
@@ -86,3 +86,41 @@ Health::checks([
         ->atLeastSizeInMb(20),
 ]);
 ```
+
+### Check backups on external filesystems
+
+You can use the `onDisk` method to specify any disk you have configured in Laravel.
+This is useful when the backups are stored on an external filesystem.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\BackupsCheck;
+
+Health::checks([
+    BackupsCheck::new()
+        ->onDisk('backups')
+        ->locatedAt('backups'),
+]);
+```
+
+Checking backup files on external filesystems can be slow if you have a lot of backup files.
+* You can use the `parseModifiedFormat` method to get the modified date of the file from the name instead of reaching out to the file and read its metadata. This strips out the file folder and file extension and uses the remaining string to parse the date with `Carbon::createFromFormat`.
+* You can also limit the size check to only the first and last backup files by using the `onlyCheckSizeOnFirstAndLast` method. Otherwise the check needs to reach out to all files and check the file sizes.
+
+These two things can speed up the check of ~200 files on an S3 bucket from about 30 seconds to about 1 second.
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Checks\Checks\BackupsCheck;
+
+Health::checks([
+    BackupsCheck::new()
+        ->onDisk('backups')
+        ->parseModifiedFormat('Y-m-d_H-i-s'),
+        ->atLeastSizeInMb(20),
+        ->onlyCheckSizeOnFirstAndLast()
+]);
+```
+
+For files that contains more than just the date you can use something like parseModifiedFormat('\b\a\c\k\u\p_Ymd_His')
+which would parse a file with the name similar to `backup_20240101_120000.sql.zip`.

--- a/src/Checks/Checks/BackupsCheck.php
+++ b/src/Checks/Checks/BackupsCheck.php
@@ -22,7 +22,7 @@ class BackupsCheck extends Check
 
     protected ?Carbon $oldestShouldHaveBeenMadeAfter = null;
 
-    protected string $parseModifiedUsing = 'Y-m-d_H-i-s';
+    protected ?string $parseModifiedUsing = null;
 
     protected int $minimumSizeInMegabytes = 0;
 
@@ -126,7 +126,7 @@ class BackupsCheck extends Check
         $oldestBackup = $this->getOldestBackup($eligableBackups);
 
         if ($this->oldestShouldHaveBeenMadeAfter) {
-            if (!$oldestBackup || $this->oldestBackupIsTooYoung($eligableBackups)) {
+            if (!$oldestBackup || $this->oldestBackupIsTooYoung($oldestBackup)) {
                 return Result::make()
                     ->failed('Oldest backup was too young');
             }

--- a/src/Checks/Checks/BackupsCheck.php
+++ b/src/Checks/Checks/BackupsCheck.php
@@ -39,7 +39,7 @@ class BackupsCheck extends Check
         return $this;
     }
 
-    public function onDisk($disk)
+    public function onDisk($disk): static
     {
         $this->disk = Storage::disk($disk);
 

--- a/src/Checks/Checks/BackupsCheck.php
+++ b/src/Checks/Checks/BackupsCheck.php
@@ -53,13 +53,6 @@ class BackupsCheck extends Check
         return $this;
     }
 
-    public function onDisk($disk)
-    {
-        $this->disk = Storage::disk($disk);
-
-        return $this;
-    }
-
     public function youngestBackShouldHaveBeenMadeBefore(Carbon $date): self
     {
         $this->youngestShouldHaveBeenMadeBefore = $date;

--- a/src/Checks/Result.php
+++ b/src/Checks/Result.php
@@ -103,6 +103,13 @@ class Result
         return $this;
     }
 
+    public function appendMeta($meta): self
+    {
+        $this->meta = array_merge($this->meta, $meta);
+
+        return $this;
+    }
+
     public function endedAt(CarbonInterface $carbon): self
     {
         $this->ended_at = $carbon;

--- a/src/Support/BackupFile.php
+++ b/src/Support/BackupFile.php
@@ -2,7 +2,10 @@
 
 namespace Spatie\Health\Support;
 
+use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 
 class BackupFile
@@ -12,6 +15,7 @@ class BackupFile
     public function __construct(
         protected string $path,
         protected ?Filesystem $disk = null,
+        protected ?string $parseModifiedUsing = null,
     ) {
         if (! $disk) {
             $this->file = new SymfonyFile($path);
@@ -28,8 +32,20 @@ class BackupFile
         return $this->file ? $this->file->getSize() : $this->disk->size($this->path);
     }
 
-    public function lastModified(): int
+    public function lastModified(): ?int
     {
+        if ($this->parseModifiedUsing) {
+            $filename = Str::before($this->path, '.');
+
+            $format = 'Y-m-d_H-i-s';
+
+            try {
+                return Carbon::createFromFormat($format, $filename)->timestamp;
+            } catch (InvalidFormatException $e) {
+                return null;
+            }
+        }
+
         return $this->file ? $this->file->getMTime() : $this->disk->lastModified($this->path);
     }
 }

--- a/src/Support/BackupFile.php
+++ b/src/Support/BackupFile.php
@@ -35,12 +35,10 @@ class BackupFile
     public function lastModified(): ?int
     {
         if ($this->parseModifiedUsing) {
-            $filename = Str::before($this->path, '.');
-
-            $format = 'Y-m-d_H-i-s';
+            $filename = Str::of($this->path)->afterLast('/')->before('.');
 
             try {
-                return Carbon::createFromFormat($format, $filename)->timestamp;
+                return Carbon::createFromFormat($this->parseModifiedUsing, $filename)->timestamp;
             } catch (InvalidFormatException $e) {
                 return null;
             }

--- a/src/Support/BackupFile.php
+++ b/src/Support/BackupFile.php
@@ -38,7 +38,7 @@ class BackupFile
             $filename = Str::of($this->path)->afterLast('/')->before('.');
 
             try {
-                return Carbon::createFromFormat($this->parseModifiedUsing, $filename)->timestamp;
+                return (int) Carbon::createFromFormat($this->parseModifiedUsing, $filename)->timestamp;
             } catch (InvalidFormatException $e) {
                 return null;
             }


### PR DESCRIPTION
We are using the BackupsCheck for Database snapshots from your [laravel-db-snapshots)](https://github.com/spatie/laravel-db-snapshots) package. We have over 200 snapshots in are storing them in a S3 bucket. Thanks for accepting our previous [PR](https://github.com/spatie/laravel-health/pull/237) to allow checking external disks. However, this introduced some performance problems. The way the current BackupsCheck work if first checks the file size of all backup files and then checks the modified date. For each check the check needs to reach out to the external file and fetch that information. This takes somewhere around 0.05 - 0.1 seconds per check per file. With 200 backup files this takes up to about 200 * 2 * 0.1 = 40 seconds. That is obviously not OK. 

This PR addresses that in two ways:
- We added the option to parse the modified date from the file name instead of reaching out to the file and check the meta data. This can be enabled with `->parseModifiedFormat('Y-m-d_H-i-s')`
- We also added the option to only check the size of the youngest and the oldest backup with `->onlyCheckSizeOnFirstAndLast()`

Those two things reduced the execution time for the check from about 30 seconds to somewhere between 0.6 and 0.8 seconds and it should scale well with even larger amounts of files. 

We also added some metadata to the BackupsCheck and a helper function on the ´Result` class for appending metadata. This is handy for checks when you are accumulating the information as you perform the checks and don't have all the information in the beginning of the check.
It is used like this:
```php
$result = Result::make()->meta([
    'some_metadata' => 'interesting metric',
]);
//...
$result->appendMeta([
    'some_other_metadata' => 'Another interesting metric',
]);
```
This merges the appended metadata to the existing metadata instead of overwriting.