### PR TITLE
Add optional pings to horizon and schedule checks

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -106,6 +106,24 @@ return [
     ],
 
     /*
+     * You can specify a heartbeat URL for the Horizon check.
+     * This URL will be pinged if the Horizon check is successful.
+     * This way you can get notified if Horizon goes down.
+     */
+    'horizon' => [
+        'heartbeat_url' => env('HORIZON_HEARTBEAT_URL', null),
+    ],
+
+    /*
+     * You can specify a heartbeat URL for the Schedule check.
+     * This URL will be pinged if the Schedule check is successful.
+     * This way you can get notified if the schedule fails to run.
+     */
+    'schedule' => [
+        'heartbeat_url' => env('SCHEDULE_HEARTBEAT_URL', null),
+    ],
+
+    /*
      * You can set a theme for the local results page
      *
      * - light: light mode

--- a/src/Checks/Checks/HorizonCheck.php
+++ b/src/Checks/Checks/HorizonCheck.php
@@ -6,9 +6,12 @@ use Exception;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
+use Spatie\Health\Traits\Pingable;
 
 class HorizonCheck extends Check
 {
+    use Pingable;
+
     public function run(): Result
     {
         $result = Result::make();
@@ -33,6 +36,10 @@ class HorizonCheck extends Check
             return $result
                 ->warning('Horizon is running, but the status is paused.')
                 ->shortSummary('Paused');
+        }
+
+        if (config('health.horizon.heartbeat_url')) {
+            $this->pingUrl(config('health.horizon.heartbeat_url'));
         }
 
         return $result->ok()->shortSummary('Running');

--- a/src/Traits/Pingable.php
+++ b/src/Traits/Pingable.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\Health\Traits;
+
+use InvalidArgumentException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+trait Pingable
+{
+    protected int $timeout = 1; // seconds
+    protected int $retryTimes = 1;
+
+    protected function pingUrl(?string $url = null): void
+    {
+        if (! $url || empty($url)) {
+            return;
+        }
+
+        if (! $this->isValidUrl($url)) {
+            Log::error("Invalid URL provided for health check ping: {$url}");
+            return;
+        }
+
+        try {
+            Http::timeout($this->timeout)
+                ->retry($this->retryTimes)
+                ->get($url);
+        } catch (\Exception $e) {
+            Log::error('Failed to ping health check URL: ' . $e->getMessage());
+        }
+    }
+
+    protected function isValidUrl(string $url): bool
+    {
+        if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function pingTimeout(int $seconds): self
+    {
+        if ($seconds <= 0) {
+            throw new InvalidArgumentException('Timeout must be a positive integer.');
+        }
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    public function pingRetryTimes(int $times): self
+    {
+        $this->retryTimes = $times;
+
+        return $this;
+    }
+}

--- a/tests/Checks/ScheduleCheckTest.php
+++ b/tests/Checks/ScheduleCheckTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Http;
 use Spatie\Health\Checks\Checks\ScheduleCheck;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 use Spatie\Health\Enums\Status;
@@ -48,4 +49,30 @@ it('can use custom max age of the heartbeat', function () {
     testTime()->addSecond();
     $result = $this->scheduleCheck->run();
     expect($result->status)->toBe(Status::failed());
+});
+
+it('pings heartbeat url when configured', function () {
+    Http::fake();
+    config()->set('health.schedule.heartbeat_url', 'https://example.com/heartbeat');
+
+    artisan(ScheduleCheckHeartbeatCommand::class)->assertSuccessful();
+
+    $result = $this->scheduleCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://example.com/heartbeat';
+    });
+});
+
+it('does not ping heartbeat url when not configured', function () {
+    Http::fake();
+    config()->set('health.schedule.heartbeat_url', null);
+
+    artisan(ScheduleCheckHeartbeatCommand::class)->assertSuccessful();
+
+    $result = $this->scheduleCheck->run();
+    expect($result->status)->toBe(Status::ok());
+
+    Http::assertNothingSent();
 });


### PR DESCRIPTION
The Laravel Health package is a great package with many useful checks. 
An issue I identified though is that if Horizon or the scheduler stops running, Health will pick this up, but you won't get notified about this, since the very services needed to send notifications are down. 

This PR adds the simple functionality to ping a URL as part of the `HorizonCheck` and `ScheduleCheck`, allowing for a heartbeat URL to be pinged so that an external service (i.e. Envoyer) can essentially be notified that horizon (for instance) is down. 
