### PR TITLE
bump serializable-closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/database": "^8.75|^9.0|^10.0|^11.0",
         "illuminate/notifications": "^8.75|^9.0|^10.0|^11.0",
         "illuminate/support": "^8.75|^9.0|^10.0|^11.0",
-        "laravel/serializable-closure": "^1.3",
+        "laravel/serializable-closure": "^1.3|^2.0",
         "nunomaduro/termwind": "^1.0|^2.0",
         "spatie/enum": "^3.13",
         "spatie/laravel-package-tools": "^1.12.1",


### PR DESCRIPTION
support for dependency : `laravel/serializable-closure` version `2.0`,
for this package stops downgrading :

`Downgrading spatie/laravel-health (1.30.1 => 1.29.0)`
