### PR TITLE
Remove typo in crashed message

### DIFF
--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -132,7 +132,7 @@ class RunHealthChecksCommand extends Command
             Status::ok() => $this->info($okMessage),
             Status::warning() => $this->comment("{$status}: {$result->getNotificationMessage()}"),
             Status::failed() => $this->error("{$status}: {$result->getNotificationMessage()}"),
-            Status::crashed() => $this->error("{$status}}: `{$exception?->getMessage()}`"),
+            Status::crashed() => $this->error("{$status}: `{$exception?->getMessage()}`"),
             default => null,
         };
     }


### PR DESCRIPTION
I noticed there's an extraneous brace in the crashed message, so I removed it.