### PR TITLE
Refactor PHPDoc block for Health Facade

### DIFF
--- a/src/Facades/Health.php
+++ b/src/Facades/Health.php
@@ -10,7 +10,14 @@ use Spatie\Health\Testing\FakeHealth;
 use Spatie\Health\Testing\FakeValues;
 
 /**
- * @mixin \Spatie\Health\Health
+ * @method static \Spatie\Health\Health checks(array<int, Check> $checks)
+ * @method static \Spatie\Health\Health clearChecks()
+ * @method static \Illuminate\Support\Collection<int, Check> registeredChecks()
+ * @method static \Illuminate\Support\Collection<int, \Spatie\Health\ResultStores\ResultStore> resultStores()
+ * @method static \Spatie\Health\Health inlineStylesheet(string $stylesheet)
+ * @method static \Illuminate\Support\HtmlString assets()
+ *
+ * @see \Spatie\Health\Health
  */
 class Health extends Facade
 {


### PR DESCRIPTION
This pull request aims to improve developer experience by replacing the `@mixin` in the `Health` facade `src/Facades/Health.php` file to explicitly state the available static methods of the `Health` facade.

**Problem**
Using @mixin, IDEs will give a warning that "_Non static method 'checks' should not be called statically_" on the use of the `Health::checks()` facade method.

**Proposed Solution**
In similar fashion to the Laravel facades, move the static method definition to the `Health` facade PHPDoc block.This does create a little more work (duplication) to maintain the package than using `@mixin` but will provide better IDE support. 
