### PR TITLE
Add pause and resume commands for health checks

### DIFF
--- a/src/Commands/PauseHealthChecksCommand.php
+++ b/src/Commands/PauseHealthChecksCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Health\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class PauseHealthChecksCommand extends Command
+{
+    public const CACHE_KEY = 'health_paused';
+    public const DEFAULT_TTL = 300;
+
+    protected $signature = 'health:pause {seconds=' . self::DEFAULT_TTL . '}';
+    protected $description = 'Pause all health checks for the giving time';
+
+    public function handle(): int
+    {
+        $seconds = (int) $this->argument('seconds');
+
+        Cache::put(self::CACHE_KEY, true, $seconds);
+
+        $this->comment('All health check paused until ' . now()->addSeconds($seconds)->toDateTimeString());
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/ResumeHealthChecksCommand.php
+++ b/src/Commands/ResumeHealthChecksCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Health\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class ResumeHealthChecksCommand extends Command
+{
+    protected $signature = 'health:resume';
+    protected $description = 'Resume all health checks';
+
+    public function handle(): int
+    {
+        Cache::forget(PauseHealthChecksCommand::CACHE_KEY);
+
+        $this->comment('All health check resumed');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/RunHealthChecksCommand.php
+++ b/src/Commands/RunHealthChecksCommand.php
@@ -5,6 +5,7 @@ namespace Spatie\Health\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
 use Spatie\Health\Enums\Status;
@@ -25,6 +26,12 @@ class RunHealthChecksCommand extends Command
 
     public function handle(): int
     {
+        if (Cache::get(PauseHealthChecksCommand::CACHE_KEY)) {
+            $this->info('Checks paused');
+
+            return self::SUCCESS;
+        }
+
         $this->info('Running checks...');
 
         $results = $this->runChecks();

--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -5,6 +5,8 @@ namespace Spatie\Health;
 use Illuminate\Support\Facades\Route;
 use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
 use Spatie\Health\Commands\ListHealthChecksCommand;
+use Spatie\Health\Commands\PauseHealthChecksCommand;
+use Spatie\Health\Commands\ResumeHealthChecksCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 use Spatie\Health\Components\Logo;
@@ -33,7 +35,9 @@ class HealthServiceProvider extends PackageServiceProvider
                 ListHealthChecksCommand::class,
                 RunHealthChecksCommand::class,
                 ScheduleCheckHeartbeatCommand::class,
-                DispatchQueueCheckJobsCommand::class
+                DispatchQueueCheckJobsCommand::class,
+                PauseHealthChecksCommand::class,
+                ResumeHealthChecksCommand::class,
             );
     }
 

--- a/src/Http/Controllers/SimpleHealthCheckController.php
+++ b/src/Http/Controllers/SimpleHealthCheckController.php
@@ -5,6 +5,8 @@ namespace Spatie\Health\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Spatie\Health\Commands\PauseHealthChecksCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\ResultStores\ResultStore;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
@@ -13,7 +15,10 @@ class SimpleHealthCheckController
 {
     public function __invoke(Request $request, ResultStore $resultStore): Response
     {
-        if ($request->has('fresh') || config('health.oh_dear_endpoint.always_send_fresh_results')) {
+        if (
+            ($request->has('fresh') || config('health.oh_dear_endpoint.always_send_fresh_results'))
+            && Cache::missing(PauseHealthChecksCommand::CACHE_KEY)
+        ) {
             Artisan::call(RunHealthChecksCommand::class);
         }
 

--- a/tests/Commands/PauseChecksCommandTest.php
+++ b/tests/Commands/PauseChecksCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
+use Spatie\Health\Commands\PauseHealthChecksCommand;
+
+use function Pest\Laravel\artisan;
+
+it('sets cache value to true for default ttl', function () {
+    $mockRepository = Mockery::mock(Repository::class);
+
+    $mockRepository->shouldReceive('put')
+        ->once()
+        ->with(
+            PauseHealthChecksCommand::CACHE_KEY,
+            true,
+            PauseHealthChecksCommand::DEFAULT_TTL
+        )
+        ->andReturn(true);
+
+    Cache::swap($mockRepository);
+
+    Cache::shouldReceive('driver')->andReturn($mockRepository);
+
+    artisan(PauseHealthChecksCommand::class)
+        ->assertSuccessful()
+        ->expectsOutputToContain('All health check paused until');
+});
+
+it('sets cache value to true for custom ttl', function () {
+    $mockRepository = Mockery::mock(Repository::class);
+
+    $mockRepository->shouldReceive('put')
+        ->once()
+        ->with(
+            PauseHealthChecksCommand::CACHE_KEY,
+            true,
+            60
+        )
+        ->andReturn(true);
+
+    Cache::swap($mockRepository);
+
+    Cache::shouldReceive('driver')->andReturn($mockRepository);
+
+    artisan(PauseHealthChecksCommand::class, ['seconds' => '60'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('All health check paused until');
+});

--- a/tests/Commands/ResumeChecksCommandTest.php
+++ b/tests/Commands/ResumeChecksCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
+use Spatie\Health\Commands\PauseHealthChecksCommand;
+
+use Spatie\Health\Commands\ResumeHealthChecksCommand;
+use function Pest\Laravel\artisan;
+
+it('forgets cache value', function () {
+    $mockRepository = Mockery::mock(Repository::class);
+
+    $mockRepository->shouldReceive('forget')
+        ->once()
+        ->with(PauseHealthChecksCommand::CACHE_KEY)
+        ->andReturn(true);
+
+    Cache::swap($mockRepository);
+
+    Cache::shouldReceive('driver')->andReturn($mockRepository);
+
+    artisan(ResumeHealthChecksCommand::class)
+        ->assertSuccessful()
+        ->expectsOutput('All health check resumed')
+    ;
+});

--- a/tests/__snapshots__/SimpleHealthCheckControllerTest__it_does_not_perform_checks_if_checks_are_paused__1.yml
+++ b/tests/__snapshots__/SimpleHealthCheckControllerTest__it_does_not_perform_checks_if_checks_are_paused__1.yml
@@ -1,0 +1,1 @@
+healthy: true


### PR DESCRIPTION
### Description
This pull request adds the ability to temporarily pause and resume health checks during deployment or other maintenance activities. This feature helps prevent unnecessary error notifications while deployments are in progress.

### Motivation
During deployments, health checks may trigger false alarms due to temporary downtime or service unavailability. By pausing these checks, we can avoid receiving irrelevant alerts and focus on the deployment process itself.

### Usage

```bash
# will pause health checks for default 300 seconds
php artisan health:pause

# will pause health checks for 60 seconds
php artisan health:pause 60

# will resume health checks immediately
php artisan health:pause
```