### PR TITLE
Fix some typos and suggest improvements in via-oh-dear.md

### DIFF
--- a/docs/configuring-notifications/via-oh-dear.md
+++ b/docs/configuring-notifications/via-oh-dear.md
@@ -13,9 +13,9 @@ Using this package, you can register a protected endpoint where [the application
 
 Oh Dear will send an HTTP request to your application to a specific endpoint to get health check. Your application should respond with JSON containing the result of health checks.
 
-You can add such an endpoint using the spatie/laravel-health package.  To do this, must configure the `ohdear_endpoint_key` in the `health` config file.
+You can add such an endpoint using the spatie/laravel-health package.  To do this, must configure the values within the `oh_dear_endpoint` key in the `health` config file.
 
-You can publish that `health` with this command:
+You can publish that `health` file with this command:
 
 ```bash
 php artisan vendor:publish --tag="health-config"
@@ -52,7 +52,7 @@ These are some of the default values in the published `health` config file.
 ],
 ```
 
-To get started:
+To get started (all options within `oh_dear_endpoint` key):
 
 - set the `enabled` config option to `true`
 - add a `secret` (we recommend putting it in the `.env` file, just like you would do for any application secret or password)


### PR DESCRIPTION
A fix for a small typo in the documentation (key name for the Oh Dear configuration) as well as some minor phrasing suggestions in that same file.