### PR TITLE
Fixes errant reference to Health facade - should be Check facade - when creating macros for health checks

### DIFF
--- a/docs/basic-usage/conditionally-running-or-modifying-checks.md
+++ b/docs/basic-usage/conditionally-running-or-modifying-checks.md
@@ -30,7 +30,7 @@ use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Checks\DebugModeCheck;
 use Spatie\Health\Checks\Checks\RedisCheck;
 
-Health::macro('ifEnvironment', fn (string|array $envs) => app()->environment($envs));
+Check::macro('ifEnvironment', fn (string|array $envs) => $this->if(fn () => app()->environment($envs)));
 
 Health::checks([
     DebugModeCheck::new()->ifEnvironment('production')


### PR DESCRIPTION
Clarifies the macro should be defined using the Check facade