### PR TITLE
Secret Token feature

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -142,4 +142,9 @@ return [
      * check has failed
      */
     'json_results_failure_status' => 200,
+
+    /*
+     * You can specify a secret token that needs to be sent in the X-Secret-Token for secured access.
+     */
+    'secret_token' => env('HEALTH_SECRET_TOKEN') ?? null,
 ];

--- a/config/health.php
+++ b/config/health.php
@@ -142,9 +142,4 @@ return [
      * check has failed
      */
     'json_results_failure_status' => 200,
-
-    /*
-     * You can specify a secret token that needs to be sent in the X-Secret-Token for secured access.
-     */
-    'secret_token' => env('HEALTH_SECRET_TOKEN') ?? null,
 ];

--- a/docs/security/_index.md
+++ b/docs/security/_index.md
@@ -1,0 +1,4 @@
+---
+title: Security
+weight: 5
+---

--- a/docs/security/using-secret-token.md
+++ b/docs/security/using-secret-token.md
@@ -1,0 +1,26 @@
+---
+title: Using Secret Token
+weight: 1
+---
+
+If you want a simple way to protect an endpoint from unwanted access over the internet, you can use the Secret Token feature. This allows you to restrict access by requiring a predefined token to be included in requests, ensuring that only authorized clients can interact with the endpoint.
+
+## Usage
+
+Here's how you can use Secret Token to protect an endpoint:
+
+Define secret token in your `.env` file:
+
+```env
+HEALTH_SECRET_TOKEN=your-secret-token
+```
+
+Add `X-Secret-Token` in the request header:
+
+```
+X-Secret-Token: your-secret-token
+```
+
+## Warning
+Secret Token is a simple way to protect an endpoint from unwanted access over the internet. However, it is not a foolproof security measure. If you need a more secure solution, consider using a more advanced authentication method.
+

--- a/docs/security/using-secret-token.md
+++ b/docs/security/using-secret-token.md
@@ -15,6 +15,12 @@ Define secret token in your `.env` file:
 HEALTH_SECRET_TOKEN=your-secret-token
 ```
 
+Use `RequiresSecretToken` middleware in your route:
+
+```php
+Route::get('/', HealthCheckJsonResultsController::class)->middleware(RequiresSecretToken::class);
+```
+
 Add `X-Secret-Token` in the request header:
 
 ```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,10 +10,11 @@
   </logging>
   <php>
     <env name="DB_CONNECTION" value="mysql"/>
-    <env name="DB_USERNAME" value="root"/>
-    <env name="DB_DATABASE" value="laravel_health"/>
+    <env name="DB_USERNAME" value="sail"/>
+    <env name="DB_PASSWORD" value="password"/>
+    <env name="DB_DATABASE" value="laravel"/>
     <env name="DB_HOST" value="127.0.0.1"/>
-    <env name="DB_PORT" value="3306"/>
+    <env name="DB_PORT" value="3312"/>
   </php>
   <source>
     <include>

--- a/src/Http/Controllers/HealthCheckJsonResultsController.php
+++ b/src/Http/Controllers/HealthCheckJsonResultsController.php
@@ -12,6 +12,15 @@ class HealthCheckJsonResultsController
 {
     public function __invoke(Request $request, ResultStore $resultStore): Response
     {
+        if (
+            config('health.secret_token')
+            && ($request->header('X-Secret-Token') !== config('health.secret_token'))
+        ) {
+            return response(null, Response::HTTP_UNAUTHORIZED)
+                ->header('Content-Type', 'application/json')
+                ->header('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+        }
+
         if ($request->has('fresh') || config('health.oh_dear_endpoint.always_send_fresh_results')) {
             Artisan::call(RunHealthChecksCommand::class);
         }

--- a/src/Http/Controllers/HealthCheckJsonResultsController.php
+++ b/src/Http/Controllers/HealthCheckJsonResultsController.php
@@ -12,15 +12,6 @@ class HealthCheckJsonResultsController
 {
     public function __invoke(Request $request, ResultStore $resultStore): Response
     {
-        if (
-            config('health.secret_token')
-            && ($request->header('X-Secret-Token') !== config('health.secret_token'))
-        ) {
-            return response(null, Response::HTTP_UNAUTHORIZED)
-                ->header('Content-Type', 'application/json')
-                ->header('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-        }
-
         if ($request->has('fresh') || config('health.oh_dear_endpoint.always_send_fresh_results')) {
             Artisan::call(RunHealthChecksCommand::class);
         }

--- a/src/Http/Controllers/HealthCheckResultsController.php
+++ b/src/Http/Controllers/HealthCheckResultsController.php
@@ -5,7 +5,6 @@ namespace Spatie\Health\Http\Controllers;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\View\View;
 use Spatie\Health\Commands\RunHealthChecksCommand;
@@ -16,13 +15,6 @@ class HealthCheckResultsController
 {
     public function __invoke(Request $request, ResultStore $resultStore, Health $health): JsonResponse|View
     {
-        if (
-            config('health.secret_token')
-            && ($request->header('X-Secret-Token') !== config('health.secret_token'))
-        ) {
-            return response()->json(null, Response::HTTP_UNAUTHORIZED);
-        }
-
         if ($request->has('fresh')) {
             Artisan::call(RunHealthChecksCommand::class);
         }

--- a/src/Http/Controllers/HealthCheckResultsController.php
+++ b/src/Http/Controllers/HealthCheckResultsController.php
@@ -5,6 +5,7 @@ namespace Spatie\Health\Http\Controllers;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\View\View;
 use Spatie\Health\Commands\RunHealthChecksCommand;
@@ -15,6 +16,13 @@ class HealthCheckResultsController
 {
     public function __invoke(Request $request, ResultStore $resultStore, Health $health): JsonResponse|View
     {
+        if (
+            config('health.secret_token')
+            && ($request->header('X-Secret-Token') !== config('health.secret_token'))
+        ) {
+            return response()->json(null, Response::HTTP_UNAUTHORIZED);
+        }
+
         if ($request->has('fresh')) {
             Artisan::call(RunHealthChecksCommand::class);
         }

--- a/src/Http/Controllers/SimpleHealthCheckController.php
+++ b/src/Http/Controllers/SimpleHealthCheckController.php
@@ -16,15 +16,6 @@ class SimpleHealthCheckController
     public function __invoke(Request $request, ResultStore $resultStore): Response
     {
         if (
-            config('health.secret_token')
-            && ($request->header('X-Secret-Token') !== config('health.secret_token'))
-        ) {
-            return response(null, Response::HTTP_UNAUTHORIZED)
-                ->header('Content-Type', 'application/json')
-                ->header('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-        }
-
-        if (
             ($request->has('fresh') || config('health.oh_dear_endpoint.always_send_fresh_results'))
             && Cache::missing(PauseHealthChecksCommand::CACHE_KEY)
         ) {

--- a/src/Http/Controllers/SimpleHealthCheckController.php
+++ b/src/Http/Controllers/SimpleHealthCheckController.php
@@ -16,6 +16,15 @@ class SimpleHealthCheckController
     public function __invoke(Request $request, ResultStore $resultStore): Response
     {
         if (
+            config('health.secret_token')
+            && ($request->header('X-Secret-Token') !== config('health.secret_token'))
+        ) {
+            return response(null, Response::HTTP_UNAUTHORIZED)
+                ->header('Content-Type', 'application/json')
+                ->header('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+        }
+
+        if (
             ($request->has('fresh') || config('health.oh_dear_endpoint.always_send_fresh_results'))
             && Cache::missing(PauseHealthChecksCommand::CACHE_KEY)
         ) {

--- a/src/Http/Middleware/RequiresSecretToken.php
+++ b/src/Http/Middleware/RequiresSecretToken.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\Health\Http\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresSecretToken
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (
+            config('health.secret_token')
+            && ($request->headers->get('X-Secret-Token') !== config('health.secret_token'))
+        ) {
+            abort(403, 'Incorrect secret token');
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/Http/Controllers/HealthCheckJsonResultsControllerTest.php
+++ b/tests/Http/Controllers/HealthCheckJsonResultsControllerTest.php
@@ -35,21 +35,6 @@ it('will display the results as json when the request accepts json', function ()
     assertMatchesSnapshot($json);
 });
 
-it('will return 401 when secret token is defined and not send in header', function () {
-    config()->set('health.secret_token', 'my-secret-token');
-
-    getJson('/')
-        ->assertUnauthorized();
-});
-
-it('will display the results when token is defined and send in header', function () {
-    config()->set('health.secret_token', 'my-secret-token');
-
-    getJson('/', ['X-Secret-Token' => 'my-secret-token'])
-        ->assertSuccessful()
-        ->json();
-});
-
 it('the output of the json endpoint can be used to create a StoredCheckResults object', function () {
     artisan(RunHealthChecksCommand::class);
 

--- a/tests/Http/Controllers/HealthCheckJsonResultsControllerTest.php
+++ b/tests/Http/Controllers/HealthCheckJsonResultsControllerTest.php
@@ -35,6 +35,22 @@ it('will display the results as json when the request accepts json', function ()
     assertMatchesSnapshot($json);
 });
 
+it('will return 401 when secret token is defined and not send in header', function () {
+    config()->set('health.secret_token', 'my-secret-token');
+
+    getJson('/')
+        ->assertUnauthorized();
+});
+
+it('will display the results when token is defined and send in header', function () {
+    config()->set('health.secret_token', 'my-secret-token');
+
+    getJson('/', ['X-Secret-Token' => 'my-secret-token'])
+        ->assertSuccessful()
+        ->json();
+});
+
+
 it('the output of the json endpoint can be used to create a StoredCheckResults object', function () {
     artisan(RunHealthChecksCommand::class);
 

--- a/tests/Http/Controllers/HealthCheckJsonResultsControllerTest.php
+++ b/tests/Http/Controllers/HealthCheckJsonResultsControllerTest.php
@@ -35,6 +35,21 @@ it('will display the results as json when the request accepts json', function ()
     assertMatchesSnapshot($json);
 });
 
+it('will return 401 when secret token is defined and not send in header', function () {
+    config()->set('health.secret_token', 'my-secret-token');
+
+    getJson('/')
+        ->assertUnauthorized();
+});
+
+it('will display the results when token is defined and send in header', function () {
+    config()->set('health.secret_token', 'my-secret-token');
+
+    getJson('/', ['X-Secret-Token' => 'my-secret-token'])
+        ->assertSuccessful()
+        ->json();
+});
+
 it('the output of the json endpoint can be used to create a StoredCheckResults object', function () {
     artisan(RunHealthChecksCommand::class);
 


### PR DESCRIPTION
The secret_token functionality has been added to provide simple protection for endpoints.

**Problem:**
Wanting to easily read health checks from various monitoring tools, not just OhDear, we don't have a simple way to restrict access to them. Separate actions need to be created, containing the part of the code that I added.