### PR TITLE
Fix documentation: Correct method name from ignorePackages to ignored…

### DIFF
--- a/docs/available-checks/security-advisories.md
+++ b/docs/available-checks/security-advisories.md
@@ -40,11 +40,11 @@ Health::checks([
 ]);
 ```
 
-You can ignore multiple packages in one go with the `ignorePackages` method.
+You can ignore multiple packages in one go with the `ignoredPackages` method.
 
 ```php
 Health::checks([
-    SecurityAdvisoriesCheck::new()->ignorePackages([
+    SecurityAdvisoriesCheck::new()->ignoredPackages([
        'spatie/laravel-backup',
        'spatie/laravel-medialibrary',
    ]),


### PR DESCRIPTION
### Summary
This pull request updates the documentation to correct the method name from `ignorePackages` to `ignoredPackages`.

### Details
While reviewing the package documentation, I noticed that the method was incorrectly referred to as `ignorePackages`. This change ensures that the documentation accurately reflects the actual method name, which helps prevent confusion for users.

### Impact
This fix improves the clarity and accuracy of the documentation, making it easier for users to understand how to use the package correctly.

### Related Issues
(If applicable, link to any related issues or discussions here)