### PR TITLE
Add configuration option for treating skipped checks as failures

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -147,4 +147,12 @@ return [
      * You can specify a secret token that needs to be sent in the X-Secret-Token for secured access.
      */
     'secret_token' => env('HEALTH_SECRET_TOKEN') ?? null,
+
+
+    /**
+     * By default, conditionally skipped health checks are treated as failures.
+     * You can override this behavior by uncommenting the configuration below.
+     * @link https://spatie.be/docs/laravel-health/v1/basic-usage/conditionally-running-or-modifying-checks
+     */
+    //'treat_skipped_as_failure' => false
 ];

--- a/docs/basic-usage/conditionally-running-or-modifying-checks.md
+++ b/docs/basic-usage/conditionally-running-or-modifying-checks.md
@@ -19,6 +19,11 @@ Health::checks([
 ]);
 ```
 
+> **Important!**  
+> Be cautious when conditionally running or modifying checks. By default, skipped checks are considered failures, which
+may impact the overall health status. You can adjust this behavior by setting the configuration option
+`treat_skipped_as_failure` to `false` in the health config file.
+
 ## Custom condition methods
 
 You may find yourself repeating conditions for multiple checks. To avoid that, 

--- a/tests/ResultStores/StoredCheckResultsTest.php
+++ b/tests/ResultStores/StoredCheckResultsTest.php
@@ -28,6 +28,32 @@ it('has a method to check if one or more checks are failing', function () {
     expect($storedCheckResults->containsFailingCheck())->toBeTrue();
 });
 
+it('should not treat skipped checks as failing checks if treat_skipped_as_failure is disabled', function () {
+    config()->set('health.treat_skipped_as_failure', false);
+    $storedCheckResults = new StoredCheckResults(new DateTime, collect([
+        makeStoredCheckResultWithStatus(Status::skipped()),
+        makeStoredCheckResultWithStatus(Status::ok()),
+    ]));
+    expect($storedCheckResults->containsFailingCheck())->toBeFalse();
+});
+
+it('should treat skipped checks as failing checks if treat_skipped_as_failure is enabled', function () {
+    config()->set('health.treat_skipped_as_failure', true);
+    $storedCheckResults = new StoredCheckResults(new DateTime, collect([
+        makeStoredCheckResultWithStatus(Status::skipped()),
+        makeStoredCheckResultWithStatus(Status::ok()),
+    ]));
+    expect($storedCheckResults->containsFailingCheck())->toBeTrue();
+});
+
+it('should treat skipped checks as failing checks if treat_skipped_as_failure is not defined', function () {
+    $storedCheckResults = new StoredCheckResults(new DateTime, collect([
+        makeStoredCheckResultWithStatus(Status::skipped()),
+        makeStoredCheckResultWithStatus(Status::ok()),
+    ]));
+    expect($storedCheckResults->containsFailingCheck())->toBeTrue();
+});
+
 it('has a method to check if all checks are good', function () {
     $storedCheckResults = new StoredCheckResults(new DateTime, collect([
         makeStoredCheckResultWithStatus(Status::ok()),


### PR DESCRIPTION
## Description
This PR adds a new configuration option `treat_skipped_as_failure` that allows users to control whether skipped health checks should be considered as failing checks. By default, skipped checks are treated as failures, maintaining the current behavior.

## Changes
- Added a new configuration option `treat_skipped_as_failure` (defaults to `true`)
- Modified the `containsFailingCheck()` method to respect this configuration
- Added tests to verify both configuration states work as expected

## Why?
In some environments, users may want to implement more lenient health check policies where skipped checks are not considered failures. This configuration makes the behavior customizable to accommodate different use cases.

This change is fully backward compatible and doesn't introduce any breaking changes. The default configuration maintains the current system behavior, while providing an opt-in mechanism for those who want to change it.

## Example Usage
``` php
// config/health.php
return [
    // Other configuration...
    'treat_skipped_as_failure' => true, // Default behavior
    // When set to false, skipped checks will not be considered failures
];
```
## Testing
Added test cases to verify:
- Skipped checks are treated as failures (default behavior)
- Skipped checks are not treated as failures when the config option is disabled
