### PR TITLE
Fix symfony console 7.3 deprecations on command classes

### DIFF
--- a/src/Commands/DispatchQueueCheckJobsCommand.php
+++ b/src/Commands/DispatchQueueCheckJobsCommand.php
@@ -12,6 +12,8 @@ class DispatchQueueCheckJobsCommand extends Command
 {
     protected $signature = 'health:queue-check-heartbeat';
 
+    protected $description = 'Dispatch health check jobs for all monitored queues.';
+
     public function handle(): int
     {
         /** @var QueueCheck|null $queueCheck */

--- a/src/Commands/ScheduleCheckHeartbeatCommand.php
+++ b/src/Commands/ScheduleCheckHeartbeatCommand.php
@@ -11,6 +11,8 @@ class ScheduleCheckHeartbeatCommand extends Command
 {
     protected $signature = 'health:schedule-check-heartbeat';
 
+    protected $description = 'Set the heartbeat for the schedule health check.';
+
     public function handle(): int
     {
         /** @var ScheduleCheck|null $scheduleCheck */


### PR DESCRIPTION
Adds missing $description properties to Health command classes to avoid Symfony 7.3 deprecation warnings related to getDefaultDescription().