### PR TITLE
rename: fix Meilisearch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,7 @@ All notable changes to `laravel-health` will be documented in this file.
 
 ### What's Changed
 
-* Add running status to MeiliSearchCheck by @francoism90 in https://github.com/spatie/laravel-health/pull/225
+* Add running status to MeilisearchCheck by @francoism90 in https://github.com/spatie/laravel-health/pull/225
 
 ### New Contributors
 
@@ -1138,7 +1138,7 @@ Only report unique checks
 
 ## 1.7.0 - 2021-12-21
 
-- add `MeiliSearchCheck`
+- add `MeilisearchCheck`
 
 ## 1.6.0 - 2021-12-17
 

--- a/docs/available-checks/meilisearch.md
+++ b/docs/available-checks/meilisearch.md
@@ -1,9 +1,9 @@
 ---
-title: MeiliSearch
+title: Meilisearch
 weight: 14
 ---
 [meilisearch.md](meilisearch.md)
-This check will verify if MeiliSearch is running. It will call MeiliSearch's [built-in health endpoint](https://docs.meilisearch.com/reference/api/health.html) and verify that its status returns `available`.
+This check will verify if Meilisearch is running. It will call Meilisearch's [built-in health endpoint](https://docs.meilisearch.com/reference/api/health.html) and verify that its status returns `available`.
 
 ## Usage
 
@@ -11,10 +11,10 @@ Here's how you can register the check.
 
 ```php
 use Spatie\Health\Facades\Health;
-use Spatie\Health\Checks\Checks\MeiliSearchCheck;
+use Spatie\Health\Checks\Checks\MeilisearchCheck;
 
 Health::checks([
-    MeiliSearchCheck::new(),
+    MeilisearchCheck::new(),
 ]);
 ```
 
@@ -26,10 +26,10 @@ You can use `url()` method to change that url.
 
 ```php
 use Spatie\Health\Facades\Health;
-use Spatie\Health\Checks\Checks\MeiliSearchCheck;
+use Spatie\Health\Checks\Checks\MeilisearchCheck;
 
 Health::checks([
-    MeiliSearchCheck::new()->url("https://your-custom-url:1234/custom-endpoint"),
+    MeilisearchCheck::new()->url("https://your-custom-url:1234/custom-endpoint"),
 ]);
 ```
 
@@ -41,10 +41,10 @@ You can use `timeout()` to set the maximum number of seconds the HTTP request sh
 
 ```php
 use Spatie\Health\Facades\Health;
-use Spatie\Health\Checks\Checks\MeiliSearchCheck;
+use Spatie\Health\Checks\Checks\MeilisearchCheck;
 
 Health::checks([
-    MeiliSearchCheck::new()->timeout(2),
+    MeilisearchCheck::new()->timeout(2),
 ]);
 ```
 
@@ -54,9 +54,9 @@ You can use `token()` to add an authorization header to the request.
 
 ```php
 use Spatie\Health\Facades\Health;
-use Spatie\Health\Checks\Checks\MeiliSearchCheck;
+use Spatie\Health\Checks\Checks\MeilisearchCheck;
 
 Health::checks([
-    MeiliSearchCheck::new()->token('auth-token'),
+    MeilisearchCheck::new()->token('auth-token'),
 ]);
 ```

--- a/docs/available-checks/overview.md
+++ b/docs/available-checks/overview.md
@@ -17,7 +17,7 @@ These are the checks created by us:
 - [Environment](environment)
 - [Flare Error Count](flare-error-count)
 - [Horizon](horizon)
-- [MeiliSearch](meilisearch)
+- [Meilisearch](meilisearch)
 - [Ping](ping)
 - [Queue](queue)
 - [Redis](redis)

--- a/src/Checks/Checks/MeilisearchCheck.php
+++ b/src/Checks/Checks/MeilisearchCheck.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
 
-class MeiliSearchCheck extends Check
+class MeilisearchCheck extends Check
 {
     protected int $timeout = 1;
 

--- a/tests/Checks/MeilisearchCheckTest.php
+++ b/tests/Checks/MeilisearchCheckTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
-use Spatie\Health\Checks\Checks\MeiliSearchCheck;
+use Spatie\Health\Checks\Checks\MeilisearchCheck;
 use Spatie\Health\Enums\Status;
 
 it('will determine that a working meilisearch is ok', function () {
@@ -9,7 +9,7 @@ it('will determine that a working meilisearch is ok', function () {
         '*' => Http::response(['status' => 'available']),
     ]);
 
-    $result = MeiliSearchCheck::new()->run();
+    $result = MeilisearchCheck::new()->run();
 
     expect($result->status)->toBe(Status::ok());
 });
@@ -19,7 +19,7 @@ it('will determine that another status is not ok', function () {
         '*' => Http::response(['status' => 'not ok']),
     ]);
 
-    $result = MeiliSearchCheck::new()->run();
+    $result = MeilisearchCheck::new()->run();
 
     expect($result->status)->toBe(Status::failed());
 });
@@ -29,7 +29,7 @@ it('will determine that an http error is not ok', function () {
         '*' => Http::response(status: 500),
     ]);
 
-    $result = MeiliSearchCheck::new()->run();
+    $result = MeilisearchCheck::new()->run();
 
     expect($result->status)->toBe(Status::failed());
 });


### PR DESCRIPTION
The capitalization of Meilisearch is without a capital S:

<img width="894" height="238" alt="CleanShot 2025-07-23 at 21 00 40@2x" src="https://github.com/user-attachments/assets/39518d23-5c33-40d6-80f3-0657d9caf09b" />

This PR renames all references from `MeiliSearch` to `Meilisearch`. This is not a breaking change as PHP class instantiation is not case sensitive.

Thanks!