### PR TITLE
feat: Add endpoint for nagios health check

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -105,6 +105,26 @@ return [
         'url' => '/oh-dear-health-check-results',
     ],
 
+    'nagios_endpoint' => [
+        'enabled' => false,
+
+        /*
+         * When this option is enabled, the checks will run before sending a response.
+         * Otherwise, we'll send the results from the last time the checks have run.
+         */
+        'always_send_fresh_results' => true,
+
+        /*
+         * The secret that is sent as auth bearer token.
+         */
+        'bearer_token' => env('NAGIOS_HEALTH_BEARER_TOKEN'),
+
+        /*
+         * The URL that should be configured nagios to check for application health.
+         */
+        'url' => '/health/nagios',
+    ],
+
     /*
      * You can specify a heartbeat URL for the Horizon check.
      * This URL will be pinged if the Horizon check is successful.

--- a/docs/configuring-notifications/general.md
+++ b/docs/configuring-notifications/general.md
@@ -10,6 +10,7 @@ Out of the box, the notification can be sent:
 - via [mail](/docs/laravel-health/v1/configuring-notifications/via-mail), 
 - via [Slack](/docs/laravel-health/v1/configuring-notifications/via-slack)
 - via [Oh Dear](/docs/laravel-health/v1/configuring-notifications/via-oh-dear) (enables snoozing notifications, and delivery via Telegram, Discord, MS Teams, webhooks, ...)
+- via [Nagios](/docs/laravel-health/v1/configuring-notifications/via-nagios) (monitoring endpoint for Nagios integration, can send notifications via email, SMS, or other methods)
 
 ## Throttling notifications
 

--- a/docs/configuring-notifications/via-nagios.md
+++ b/docs/configuring-notifications/via-nagios.md
@@ -46,46 +46,12 @@ For security, you should configure a bearer token that Nagios will use to authen
 NAGIOS_HEALTH_BEARER_TOKEN=your-secret-token-here
 ```
 
-### Fresh Results vs Cached Results
-
-- **`always_send_fresh_results => true`**: Health checks will run every time Nagios calls the endpoint (recommended for critical monitoring)
-- **`always_send_fresh_results => false`**: Returns the results from the last scheduled health check run (better performance)
-
 ### Custom Endpoint URL
 
 You can customize the endpoint URL by changing the `url` configuration:
 
 ```php
 'url' => '/custom/nagios/health',
-```
-
-## Setting up Nagios
-
-Once configured, you can add your Laravel application to your Nagios configuration:
-
-### Basic Nagios Service Definition
-
-```nagios
-define service {
-    use                     generic-service
-    host_name               your-web-server
-    service_description     Laravel Health Check
-    check_command           check_http_bearer_token!your-secret-token-here!/health/nagios
-    check_interval          5
-    retry_interval          1
-    max_check_attempts      3
-}
-```
-
-### Custom Check Command (if needed)
-
-You may need to define a custom check command that includes bearer token authentication:
-
-```nagios
-define command {
-    command_name    check_http_bearer_token
-    command_line    $USER1$/check_http -H $HOSTADDRESS$ -u $ARG2$ -A "Bearer $ARG1$" -t 30
-}
 ```
 
 ## Response Format

--- a/docs/configuring-notifications/via-nagios.md
+++ b/docs/configuring-notifications/via-nagios.md
@@ -1,0 +1,136 @@
+---
+title: Via Nagios
+weight: 5
+---
+
+[Nagios](https://www.nagios.org/) is a popular open-source monitoring system that helps organizations monitor their IT infrastructure, including servers, applications, services, and network devices. It provides alerting capabilities when problems are detected and can send notifications via email, SMS, or other methods.
+
+The package provides a dedicated endpoint for Nagios monitoring systems. This endpoint returns health check results in a format that Nagios can understand, allowing you to integrate your Laravel application's health status into your existing Nagios monitoring infrastructure.
+
+## Enabling the Nagios endpoint
+
+To enable the Nagios monitoring endpoint, you need to configure it in your `config/health.php` file:
+
+```php
+// in config/health.php
+
+'nagios_endpoint' => [
+    'enabled' => true,
+
+    /*
+     * When this option is enabled, the checks will run before sending a response.
+     * Otherwise, we'll send the results from the last time the checks have run.
+     */
+    'always_send_fresh_results' => true,
+
+    /*
+     * The secret that is sent as auth bearer token.
+     */
+    'bearer_token' => env('NAGIOS_HEALTH_BEARER_TOKEN'),
+
+    /*
+     * The URL that should be configured nagios to check for application health.
+     */
+    'url' => '/health/nagios',
+],
+```
+
+## Configuration options
+
+### Bearer Token Authentication
+
+For security, you should configure a bearer token that Nagios will use to authenticate with your endpoint:
+
+```bash
+# Add to your .env file
+NAGIOS_HEALTH_BEARER_TOKEN=your-secret-token-here
+```
+
+### Fresh Results vs Cached Results
+
+- **`always_send_fresh_results => true`**: Health checks will run every time Nagios calls the endpoint (recommended for critical monitoring)
+- **`always_send_fresh_results => false`**: Returns the results from the last scheduled health check run (better performance)
+
+### Custom Endpoint URL
+
+You can customize the endpoint URL by changing the `url` configuration:
+
+```php
+'url' => '/custom/nagios/health',
+```
+
+## Setting up Nagios
+
+Once configured, you can add your Laravel application to your Nagios configuration:
+
+### Basic Nagios Service Definition
+
+```nagios
+define service {
+    use                     generic-service
+    host_name               your-web-server
+    service_description     Laravel Health Check
+    check_command           check_http_bearer_token!your-secret-token-here!/health/nagios
+    check_interval          5
+    retry_interval          1
+    max_check_attempts      3
+}
+```
+
+### Custom Check Command (if needed)
+
+You may need to define a custom check command that includes bearer token authentication:
+
+```nagios
+define command {
+    command_name    check_http_bearer_token
+    command_line    $USER1$/check_http -H $HOSTADDRESS$ -u $ARG2$ -A "Bearer $ARG1$" -t 30
+}
+```
+
+## Response Format
+
+The Nagios endpoint returns responses in the standard Nagios plugin format:
+
+- **OK**: All health checks are passing
+- **WARNING**: Some checks have warnings but no critical failures
+- **CRITICAL**: One or more checks have failed critically
+- **UNKNOWN**: No health check results are available
+
+Example responses:
+
+```
+OK: All health checks are passing (5 checks)
+WARNING: Database connection slow (1 warning, 4 ok)
+CRITICAL: Queue connection failed (1 critical, 3 ok, 1 warning)
+```
+
+## Testing the Endpoint
+
+You can test the endpoint manually to ensure it's working correctly:
+
+```bash
+# Without authentication (if bearer_token is not set)
+curl https://your-app.com/health/nagios
+
+# With bearer token authentication
+curl -H "Authorization: Bearer your-secret-token-here" https://your-app.com/health/nagios
+
+# Force fresh results
+curl -H "Authorization: Bearer your-secret-token-here" https://your-app.com/health/nagios?fresh=1
+```
+
+## Troubleshooting
+
+### Authentication Issues
+
+If you're getting 401 Unauthorized responses:
+- Verify the bearer token is correctly set in your `.env` file
+- Ensure Nagios is sending the token in the correct format: `Authorization: Bearer your-token`
+
+### No Results Available
+
+If you see "UNKNOWN: No health check results available":
+- Run the health checks manually: `php artisan health:check`
+- Verify your health checks are properly configured
+- Check that the scheduled health check command is running

--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -12,6 +12,7 @@ use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 use Spatie\Health\Components\Logo;
 use Spatie\Health\Components\StatusIndicator;
 use Spatie\Health\Http\Controllers\HealthCheckJsonResultsController;
+use Spatie\Health\Http\Controllers\NagiosHealthCheckResultsController;
 use Spatie\Health\Http\Middleware\RequiresSecret;
 use Spatie\Health\Jobs\HealthQueueJob;
 use Spatie\Health\ResultStores\ResultStore;
@@ -55,7 +56,8 @@ class HealthServiceProvider extends PackageServiceProvider
 
         $this
             ->registerOhDearEndpoint()
-            ->silenceHealthQueueJob();
+            ->silenceHealthQueueJob()
+            ->registerNagiosEndpoint();
     }
 
     protected function registerOhDearEndpoint(): self
@@ -93,6 +95,14 @@ class HealthServiceProvider extends PackageServiceProvider
         $silencedJobs[] = HealthQueueJob::class;
 
         config()->set('horizon.silenced', $silencedJobs);
+
+        return $this;
+    }
+
+    protected function registerNagiosEndpoint(): self
+    {
+        Route::get('health/nagios', NagiosHealthCheckResultsController::class)
+            ->middleware(config('health.middleware', []));
 
         return $this;
     }

--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -13,6 +13,7 @@ use Spatie\Health\Components\Logo;
 use Spatie\Health\Components\StatusIndicator;
 use Spatie\Health\Http\Controllers\HealthCheckJsonResultsController;
 use Spatie\Health\Http\Controllers\NagiosHealthCheckResultsController;
+use Spatie\Health\Http\Middleware\RequiresBearerToken;
 use Spatie\Health\Http\Middleware\RequiresSecret;
 use Spatie\Health\Jobs\HealthQueueJob;
 use Spatie\Health\ResultStores\ResultStore;
@@ -101,8 +102,20 @@ class HealthServiceProvider extends PackageServiceProvider
 
     protected function registerNagiosEndpoint(): self
     {
-        Route::get('health/nagios', NagiosHealthCheckResultsController::class)
-            ->middleware(config('health.middleware', []));
+        if (! config('health.nagios_endpoint.enabled')) {
+            return $this;
+        }
+
+        if (! config('health.nagios_endpoint.bearer_token')) {
+            return $this;
+        }
+
+        if (! config('health.nagios_endpoint.url')) {
+            return $this;
+        }
+
+        Route::get(config('health.nagios_endpoint.url'), NagiosHealthCheckResultsController::class)
+            ->middleware(RequiresBearerToken::class);
 
         return $this;
     }

--- a/src/Http/Controllers/NagiosHealthCheckResultsController.php
+++ b/src/Http/Controllers/NagiosHealthCheckResultsController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\Health\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Spatie\Health\ResultStores\ResultStore;
+use Spatie\Health\ResultFormats\NagiosResultsFormat;
+
+class NagiosHealthCheckResultsController
+{
+    public function __invoke(ResultStore $resultStore): Response
+    {
+        $checkResults = $resultStore->latestResults();
+
+        if ($checkResults === null) {
+            return response("UNKNOWN: No health check results available", 200)
+                ->header('Content-Type', 'text/plain');
+        }
+
+        $formatter = new NagiosResultsFormat();
+        return response($formatter->format($checkResults))
+            ->header('Content-Type', 'text/plain');
+    }
+}

--- a/src/Http/Controllers/NagiosHealthCheckResultsController.php
+++ b/src/Http/Controllers/NagiosHealthCheckResultsController.php
@@ -2,14 +2,21 @@
 
 namespace Spatie\Health\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\ResultStores\ResultStore;
 use Spatie\Health\ResultFormats\NagiosResultsFormat;
 
 class NagiosHealthCheckResultsController
 {
-    public function __invoke(ResultStore $resultStore): Response
+    public function __invoke(Request $request, ResultStore $resultStore): Response
     {
+        if ($request->has('fresh') || config('health.nagios_endpoint.always_send_fresh_results')) {
+            Artisan::call(RunHealthChecksCommand::class);
+        }
+
         $checkResults = $resultStore->latestResults();
 
         if ($checkResults === null) {

--- a/src/Http/Middleware/RequiresBearerToken.php
+++ b/src/Http/Middleware/RequiresBearerToken.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\Health\Http\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresBearerToken
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (config('health.nagios_endpoint.bearer_token')) {
+            $bearerToken = $this->getBearerToken($request);
+
+            if ($bearerToken !== config('health.nagios_endpoint.bearer_token')) {
+                abort(403, 'Incorrect bearer token');
+            }
+        }
+
+        return $next($request);
+    }
+
+    private function getBearerToken(Request $request): ?string
+    {
+        $authorization = $request->headers->get('Authorization');
+
+        if ($authorization && str_starts_with($authorization, 'Bearer ')) {
+            return substr($authorization, 7);
+        }
+
+        return null;
+    }
+}

--- a/src/ResultFormats/NagiosResultsFormat.php
+++ b/src/ResultFormats/NagiosResultsFormat.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Spatie\Health\ResultFormats;
+
+use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResults;
+
+class NagiosResultsFormat implements ResultsFormat
+{
+    public function format(StoredCheckResults|null $checkResults): string
+    {
+        $status = $this->determineStatus($checkResults);
+        $perfData = $this->getPerformanceData($checkResults);
+        $details = $this->getDetails($checkResults);
+
+        $shortMessage = collect($checkResults->storedCheckResults)
+            ->filter(function ($result) use ($status) {
+                return $status === 'critical'
+                    ? strtolower($result->status) === 'failed'
+                    : strtolower($result->status) === 'warning';
+            })
+            ->map(function ($result) {
+                return $result->notificationMessage ?? $result->shortSummary;
+            })
+            ->first() ?? sprintf("%d checks executed", count($checkResults->storedCheckResults));
+
+        return sprintf(
+            "%s: %s|%s\n%s",
+            strtoupper($status),
+            $shortMessage,
+            $perfData,
+            $details
+        );
+    }
+
+    protected function determineStatus(StoredCheckResults $checkResults): string
+    {
+        $results = $checkResults->storedCheckResults;
+        $hasWarning = false;
+
+        foreach ($results as $result) {
+            if (strtolower($result->status) === 'failed') {
+                return 'critical';
+            }
+            if (strtolower($result->status) === 'warning') {
+                $hasWarning = true;
+            }
+        }
+
+        return $hasWarning ? 'warning' : 'ok';
+    }
+
+    protected function getPerformanceData(StoredCheckResults $checkResults): string
+    {
+        return collect($checkResults->storedCheckResults)
+            ->map(function ($result) {
+                if (empty($result->meta)) {
+                    return null;
+                }
+
+                $label = strtolower($result->label);
+                $value = $result->meta;
+
+                if (!is_numeric($value)) {
+                    if (is_array($value)) {
+                        $value = array_values($value)[0] ?? null;
+                    } else {
+                        return null;
+                    }
+                }
+
+                if (!is_numeric($value)) {
+                    return null;
+                }
+
+                return sprintf("'%s'=%s", $label, $value);
+            })
+            ->filter()
+            ->join(' ');
+    }
+
+    protected function getDetails(StoredCheckResults $checkResults): string
+    {
+        return collect($checkResults->storedCheckResults)
+            ->map(function ($result) {
+                $label = $result->label ?? 'Unknown Check';
+                $shortSummary = $result->notificationMessage ?? $result->shortSummary ?? 'No details available';
+                $status = strtoupper($result->status ?? 'UNKNOWN');
+
+                return sprintf(
+                    "%s: %s [%s]",
+                    $label,
+                    $shortSummary,
+                    $status
+                );
+            })
+            ->join("\n");
+    }
+}

--- a/src/ResultFormats/ResultsFormat.php
+++ b/src/ResultFormats/ResultsFormat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Health\ResultFormats;
+
+use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResults;
+
+interface ResultsFormat
+{
+    public function format(StoredCheckResults $checkResults): string;
+}

--- a/tests/Http/Controllers/NagiosHealthCheckResultsControllerTest.php
+++ b/tests/Http/Controllers/NagiosHealthCheckResultsControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Spatie\Health\Tests\Http\Controllers;
+
+use Orchestra\Testbench\TestCase;
+use Spatie\Health\Checks\Checks\DatabaseCheck;
+use Spatie\Health\Enums\Status;
+use Spatie\Health\Facades\Health;
+use Spatie\Health\HealthServiceProvider;
+use Spatie\Health\ResultStores\ResultStore;
+use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResult;
+use Spatie\Health\Tests\TestClasses\InMemoryResultStore;
+
+class NagiosHealthCheckResultsControllerTest extends TestCase
+{
+    private ResultStore $resultStore;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resultStore = new InMemoryResultStore();
+        $this->app->instance(ResultStore::class, $this->resultStore);
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            HealthServiceProvider::class,
+        ];
+    }
+
+    protected function getPackageAliases($app): array
+    {
+        return [
+            'Health' => Health::class,
+        ];
+    }
+
+    /** @test */
+    public function it_returns_nagios_formatted_results()
+    {
+        Health::checks([
+            DatabaseCheck::new(),
+        ]);
+
+        $checkResults = collect([
+            new StoredCheckResult(
+                name: 'Database',
+                label: 'Database',
+                notificationMessage: '',
+                shortSummary: 'Connection successful',
+                status: Status::ok(),
+                meta: ['response_time' => '100ms']
+            ),
+            new StoredCheckResult(
+                name: 'DiskSpace',
+                label: 'Disk Space',
+                notificationMessage: '',
+                shortSummary: 'Usage at 85%',
+                status: Status::ok(),
+                meta: ['used_space' => '85%']
+            )
+        ]);
+
+        $this->resultStore->save($checkResults);
+
+        $response = $this->get('health/nagios');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $this->assertStringContainsString('OK: 2 checks executed|' . PHP_EOL, $response->getContent());
+        $this->assertStringContainsString('Database:  [OK]', $response->getContent());
+        $this->assertStringContainsString('Disk Space:  [OK]', $response->getContent());
+    }
+
+    /** @test */
+    public function it_returns_error_status_when_checks_fail()
+    {
+        $checkResults = collect([
+            new StoredCheckResult(
+                name: 'DiskSpace',
+                label: 'Disk Space',
+                notificationMessage: '',
+                shortSummary: 'Usage at 85%',
+                status: Status::failed(),
+                meta: ['used_space' => '85%']
+            )
+        ]);
+
+        $this->resultStore->save($checkResults);
+
+        $response = $this->get('health/nagios');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $this->assertStringContainsString('CRITICAL:', $response->getContent());
+        $this->assertStringContainsString('Disk Space:  [FAILED]', $response->getContent());
+    }
+
+    /** @test */
+    public function it_handles_no_results()
+    {
+        $this->resultStore->flush();
+
+        $response = $this->get('health/nagios');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $this->assertStringContainsString('UNKNOWN', $response->getContent());
+    }
+}

--- a/tests/ResultFormats/NagiosResultFormatTest.php
+++ b/tests/ResultFormats/NagiosResultFormatTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Spatie\Health\Tests\ResultFormats;
+
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+use Spatie\Health\Enums\Status;
+use Spatie\Health\ResultFormats\NagiosResultsFormat;
+use Spatie\Health\ResultStores\StoredCheckResults\StoredCheckResults;
+
+class NagiosResultFormatTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function test_it_formats_results_correctly()
+    {
+        $mockedResults = collect([
+            (object) [
+                'status' => Status::ok()->value,
+                'label' => 'Database',
+                'shortSummary' => 'Connection successful',
+                'meta' => ['response_time' => '100ms'],
+            ],
+            (object) [
+                'status' => Status::warning()->value,
+                'label' => 'Disk Space',
+                'shortSummary' => 'Usage at 85%',
+                'meta' => ['used_space' => '85%'],
+            ],
+        ]);
+
+        $mockedStoredCheckResults = $this->createMock(StoredCheckResults::class);
+        $mockedStoredCheckResults->storedCheckResults = $mockedResults;
+
+        $formatter = new NagiosResultsFormat();
+
+        $output = $formatter->format($mockedStoredCheckResults);
+
+        $expectedOutput = <<<EOT
+WARNING: Usage at 85%|
+Database: Connection successful [OK]
+Disk Space: Usage at 85% [WARNING]
+EOT;
+
+        $this->assertEquals(trim($expectedOutput), trim($output));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_it_handles_no_checks()
+    {
+        $mockedStoredCheckResults = $this->createMock(StoredCheckResults::class);
+        $mockedStoredCheckResults->storedCheckResults = collect();
+
+        $formatter = new NagiosResultsFormat();
+
+        $output = $formatter->format($mockedStoredCheckResults);
+
+        $expectedOutput = "OK: 0 checks executed|\n";
+
+        $this->assertEquals($expectedOutput, $output);
+    }
+}

--- a/tests/TestClasses/InMemoryResultStore.php
+++ b/tests/TestClasses/InMemoryResultStore.php
@@ -22,10 +22,23 @@ class InMemoryResultStore implements ResultStore
     public function latestResults(): ?StoredCheckResults
     {
         // TODO: Implement latestReport() method.
+        if (self::$checkResults->isEmpty()) {
+            return null;
+        }
+
+        return new StoredCheckResults(
+            finishedAt: now(),
+            checkResults: self::$checkResults
+        );
     }
 
     public static function expectCheckResults(): Expectation|Extendable
     {
         return expect(self::$checkResults);
+    }
+
+    public function flush(): void
+    {
+        self::$checkResults = new Collection();
     }
 }


### PR DESCRIPTION
This pull request adds an endpoint that fetches the health check results in a format that can be consumed by nagios, and includes performance data; This implementation is already in use based on the health package on a production system and works well

The NagiosHealthCheckResultsController provides a Nagios-compatible endpoint for monitoring systems.

**Purpose and Functionality**

Endpoint: /health/nagios - Returns health check results in Nagios format
Response Format: Plain text with status indicators (OK, WARNING, CRITICAL, UNKNOWN)
Integration: Allows external monitoring tools (Nagios, Icinga, etc.) to monitor Laravel application health
Status Reporting: Converts Laravel health check results into standardized Nagios output format

**Nagios Output Format**
The controller returns responses like:

```
OK: 2 checks executed|
Database: Connection successful [OK]
Disk Space: Usage at 15% [OK]
```

Or for failures:

```
CRITICAL: Test failed|
Test Check: Failed [FAILED]
```

**Tests Added**

• Testing successful health check results - Verifies that when multiple health checks pass (like Database and Disk Space checks), the controller returns a proper Nagios "OK" response with the correct format showing all checks as successful.
• Testing failed health check scenarios - Ensures that when a health check fails (like disk space usage being too high), the controller returns a "CRITICAL" status in proper Nagios format, clearly indicating which check failed.
• Testing the no results scenario - Handles the edge case where no health check results are available yet (perhaps checks haven't been run), ensuring the controller returns an "UNKNOWN" status instead of crashing.
All tests verify that the responses have the correct Content-Type headers, HTTP status codes, and follow the standard Nagios monitoring format that external monitoring tools expect to receive.