### PR TITLE
fix: Remove int casting in QueueCheck for Carbon 3 compatibility

### DIFF
--- a/src/Checks/Checks/QueueCheck.php
+++ b/src/Checks/Checks/QueueCheck.php
@@ -83,7 +83,7 @@ class QueueCheck extends Check
 
             $carbonVersion = InstalledVersions::getVersion('nesbot/carbon');
 
-            $minutesAgo = (int) $latestHeartbeatAt->diffInMinutes();
+            $minutesAgo = $latestHeartbeatAt->diffInMinutes();
 
             if (version_compare($carbonVersion,
                 '3.0.0', '<')) {


### PR DESCRIPTION
## Problem
In Carbon 3, the `diffInMinutes()` method returns a float value instead of an integer. When we cast this value to `(int)`, it rounds down the decimal part, which causes the test to fail because the actual time difference is not properly calculated.

## Solution
Remove the `(int)` cast from line 86 in `QueueCheck.php` to allow the float value to be used directly. This ensures accurate time calculations in both Carbon 2 and Carbon 3.
