### PR TITLE
Round diffInMinutes float in failure messages

### DIFF
--- a/src/Checks/Checks/QueueCheck.php
+++ b/src/Checks/Checks/QueueCheck.php
@@ -80,7 +80,8 @@ class QueueCheck extends Check
             }
 
             if ($minutesAgo > $this->failWhenTestJobTakesLongerThanMinutes) {
-                $fails[] = "The last run of the `{$queue}` queue was more than {$minutesAgo} minutes ago.";
+                $roundedMinutes = round($minutesAgo, 2);
+                $fails[] = "The last run of the `{$queue}` queue was more than {$roundedMinutes} minutes ago.";
             }
         }
 

--- a/src/Checks/Checks/ScheduleCheck.php
+++ b/src/Checks/Checks/ScheduleCheck.php
@@ -74,7 +74,8 @@ class ScheduleCheck extends Check
         }
 
         if ($minutesAgo > $this->heartbeatMaxAgeInMinutes) {
-            return $result->failed("The last run of the schedule was more than {$minutesAgo} minutes ago.");
+            $roundedMinutes = round($minutesAgo, 2);
+            return $result->failed("The last run of the schedule was more than {$roundedMinutes} minutes ago.");
         }
 
         if (config('health.schedule.heartbeat_url')) {

--- a/tests/Checks/QueueCheckTest.php
+++ b/tests/Checks/QueueCheckTest.php
@@ -58,6 +58,17 @@ it('can use custom max age of the heartbeat for queue jobs', function () {
     expect($result->status)->toBe(Status::failed());
 })->skipOnOldCarbon();
 
+it('rounds minutes in failure message', function () {
+    artisan(DispatchQueueCheckJobsCommand::class)->assertSuccessful();
+
+    testTime()->addMinutes(5)->addSeconds(5);
+
+    $result = $this->queueCheck->run();
+
+    expect($result->status)->toBe(Status::failed())
+        ->and($result->meta)->each->toMatch('/^The last run of the `\w+` queue was more than \d+(\.\d{1,2})? minutes ago\.$/');
+})->skipOnOldCarbon();
+
 it('will fail if only one queue is not working', function () {
     Health::clearChecks();
 

--- a/tests/Checks/ScheduleCheckTest.php
+++ b/tests/Checks/ScheduleCheckTest.php
@@ -51,6 +51,17 @@ it('can use custom max age of the heartbeat', function () {
     expect($result->status)->toBe(Status::failed());
 });
 
+it('rounds minutes in failure message', function () {
+    artisan(ScheduleCheckHeartbeatCommand::class)->assertSuccessful();
+
+    testTime()->addMinutes(1)->addSeconds(5);
+
+    $result = $this->scheduleCheck->run();
+
+    expect($result->status)->toBe(Status::failed())
+        ->and($result->notificationMessage)->toMatch('/^The last run of the schedule was more than \d+(\.\d{1,2})? minutes ago\.$/');
+})->skipOnOldCarbon();
+
 it('pings heartbeat url when configured', function () {
     Http::fake();
     config()->set('health.schedule.heartbeat_url', 'https://example.com/heartbeat');


### PR DESCRIPTION
## Why

Carbon 3's `diffInMinutes()` returns a float instead of an int, causing failure messages like _"The last run of the schedule was more than 1.0127232666667 minutes ago."_ A previous fix attempt (`(int)` cast in PR #285) was reverted in PR #290 because truncation made threshold comparisons incorrect.

## What changed

- `round($minutesAgo, 2)` applied to the **display value only** in both `ScheduleCheck` and `QueueCheck` failure messages. The raw float is preserved for threshold comparison, avoiding the PR #285 regression.
- Added tests for both checks verifying the rounded output format.
