### PR TITLE
Remove 'health' container alias to prevent middleware name collision

### DIFF
--- a/src/Facades/Health.php
+++ b/src/Facades/Health.php
@@ -35,6 +35,6 @@ class Health extends Facade
 
     protected static function getFacadeAccessor()
     {
-        return 'health';
+        return \Spatie\Health\Health::class;
     }
 }

--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -44,7 +44,6 @@ class HealthServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $this->app->singleton(Health::class);
-        $this->app->alias(Health::class, 'health');
 
         $this->app->bind(ResultStore::class, fn () => ResultStores::createFromConfig()->first());
     }

--- a/tests/HealthTest.php
+++ b/tests/HealthTest.php
@@ -181,6 +181,12 @@ it('can fake checks', function () {
     }
 });
 
+it('does not register a container alias named "health" that would shadow a middleware of the same name', function () {
+    // Regression test for https://github.com/spatie/laravel-health/issues/310: a 'health' alias
+    // caused ->middleware('health') to resolve to the Health service instead of throwing.
+    expect(app()->bound('health'))->toBeFalse();
+});
+
 it('can pass a closure to fake checks', function () {
     Health::checks([
         DatabaseCheck::new()->name('MySQL')->connectionName('mysql'),


### PR DESCRIPTION
## Summary

- Drops the `$this->app->alias(Health::class, 'health')` binding in `HealthServiceProvider`.
- Points the `Health` facade accessor at `Spatie\Health\Health::class` directly so the facade keeps working without the string alias.
- Adds a regression test asserting `app()->bound('health')` is false after the provider boots.

## Why

Reported in #310 as `Object of type Spatie\Health\Health is not callable` when hitting a route registered as:

```php
Route::get('health', HealthCheckJsonResultsController::class)->name('health.json');
```

When a user has (or inherits) `->middleware('health')` on that route without a matching middleware alias, Laravel's `MiddlewareNameResolver` (`Illuminate\Routing\MiddlewareNameResolver::resolve`) passes the string through unchanged, and `Illuminate\Pipeline\Pipeline::carry` then does `$container->make('health')`. Normally this would throw a binding exception, but the package's `'health'` container alias satisfies it and returns the `Health` service. Since `Health` has no `handle()` method, the pipeline falls through to `$pipe(...)` and PHP raises "not callable."

Removing the alias lets the normal "middleware not found" error path run, which is the correct behavior.