### PR TITLE
Add domain routing for health check endpoint

### DIFF
--- a/src/HealthServiceProvider.php
+++ b/src/HealthServiceProvider.php
@@ -71,7 +71,8 @@ class HealthServiceProvider extends PackageServiceProvider
             return $this;
         }
 
-        Route::get(config('health.oh_dear_endpoint.url'), HealthCheckJsonResultsController::class)
+        Route::domain(config('health.oh_dear_endpoint.domain'))
+            ->get(config('health.oh_dear_endpoint.url'), HealthCheckJsonResultsController::class)
             ->middleware(RequiresSecret::class);
 
         return $this;


### PR DESCRIPTION
For sites using spatie/laravel-multitenancy or multiple domains in general, we need to explicitly set the domain for this route. 

Not sure if it is worth adding in the config since nobody seems to asked for this till now. Leaving it up to you.