### PR TITLE
Change mail recipient to use environment variable

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -69,7 +69,7 @@ return [
         'only_on_failure' => false,
 
         'mail' => [
-            'to' => 'your@example.com',
+            'to' => env('HEALTH_MAIL_TO', 'your@example.com'),
 
             'from' => [
                 'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),


### PR DESCRIPTION
This pull request makes a small configuration improvement by allowing the health check notification email recipient to be set via an environment variable. This makes it easier to customize the notification recipient without changing the code.

- The `to` address for health check notification emails in `config/health.php` now uses the `HEALTH_MAIL_TO` environment variable, with a fallback to `'your@example.com'`.